### PR TITLE
Week7

### DIFF
--- a/prisma/migrations/20250704131459_create_tables/migration.sql
+++ b/prisma/migrations/20250704131459_create_tables/migration.sql
@@ -78,6 +78,7 @@ CREATE TABLE `reservations` (
     `status` TINYINT NOT NULL,
     `paid_at` DATETIME(3) NULL,
     `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updated_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
 
     INDEX `reservations_user_id_idx`(`user_id`),
     UNIQUE INDEX `reservations_seat_id_key`(`seat_id`),

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -101,6 +101,7 @@ model ReservationEntity {
   status        Int        @db.TinyInt
   paidAt        DateTime?  @map("paid_at")
   createdAt     DateTime   @default(now()) @map("created_at")
+  updatedAt     DateTime   @default(now()) @map("updated_at")
 
   @@unique([seatId])
   @@index([userId])

--- a/src/common/services/redis/redis.service.ts
+++ b/src/common/services/redis/redis.service.ts
@@ -45,7 +45,7 @@ export class RedisService implements OnApplicationShutdown {
 		return this.client;
 	}
 
-	// sorted set
+	// sorted set ============================================================
 	async zadd(key: string, score: number, member: string): Promise<number> {
 		return this.client.zadd(key, score, member);
 	}
@@ -71,7 +71,27 @@ export class RedisService implements OnApplicationShutdown {
 		return this.client.incr(key);
 	}
 
-	// string
+	async zcard(key: string): Promise<number> {
+		return this.client.zcard(key);
+	}
+
+	async zscore(key: string, member: string): Promise<number> {
+		const score = await this.client.zscore(key, member);
+		if (score === null) {
+			return -1;
+		}
+		return Number(score);
+	}
+
+	async zrank(key: string, member: string): Promise<number> {
+		const rank = await this.client.zrank(key, member);
+		if (rank === null) {
+			return -1;
+		}
+		return Number(rank);
+	}
+
+	// string ============================================================
 	async set(
 		key: string,
 		value: any,
@@ -100,7 +120,7 @@ export class RedisService implements OnApplicationShutdown {
 		}
 	}
 
-	// hash map
+	// hash map ============================================================
 	async hset(
 		key: string,
 		data: Map<string | number, any> | Record<string | number, any>,

--- a/src/common/services/redis/redis.service.ts
+++ b/src/common/services/redis/redis.service.ts
@@ -45,6 +45,33 @@ export class RedisService implements OnApplicationShutdown {
 		return this.client;
 	}
 
+	// sorted set
+	async zadd(key: string, score: number, member: string): Promise<number> {
+		return this.client.zadd(key, score, member);
+	}
+
+	async zrem(key: string, member: string): Promise<number> {
+		return this.client.zrem(key, member);
+	}
+
+	async zrange(
+		key: string,
+		start: number,
+		stop: number,
+		withScores?: boolean,
+	): Promise<string[]> {
+		const options: string[] = [];
+		if (withScores) {
+			options.push('WITHSCORES');
+		}
+		return this.client.zrange(key, start, stop, ...(options as any));
+	}
+
+	async increment(key: string): Promise<number> {
+		return this.client.incr(key);
+	}
+
+	// string
 	async set(
 		key: string,
 		value: any,
@@ -55,18 +82,14 @@ export class RedisService implements OnApplicationShutdown {
 			const valueStr =
 				typeof value === 'object' ? JSON.stringify(value) : value;
 
-			let result: string;
-			if (ttl && nx) {
-				// nx는 ttl 설정 안되는 경우 있음.. -> release 잘 처리해야
-				result = await this.client.set(key, valueStr, 'EX', ttl, 'NX');
-			} else if (ttl) {
-				result = await this.client.set(key, valueStr, 'EX', ttl);
-			} else if (nx) {
-				result = await this.client.set(key, valueStr, 'NX');
-			} else {
-				result = await this.client.set(key, valueStr);
+			const options: string[] = [];
+			if (ttl) {
+				options.push('EX', ttl.toString());
 			}
-
+			if (nx) {
+				options.push('NX');
+			}
+			const result = await this.client.set(key, valueStr, ...(options as any));
 			if (result !== 'OK') {
 				throw new Error(`Failed to set key: ${key}`);
 			}
@@ -77,6 +100,7 @@ export class RedisService implements OnApplicationShutdown {
 		}
 	}
 
+	// hash map
 	async hset(
 		key: string,
 		data: Map<string | number, any> | Record<string | number, any>,

--- a/src/common/utils/redis-keys.ts
+++ b/src/common/utils/redis-keys.ts
@@ -1,3 +1,24 @@
+// sorted set 관련
+export const getDurationKey = (scheduleId: number): string => {
+	return `schedule:${scheduleId}`;
+};
+
+export const getFastSelloutRankingKey = (): string => {
+	return 'fast_sellout_ranking';
+};
+
+export const getSellingStartTimeKey = (scheduleId: number): string => {
+	return `selling_start_time:schedule:${scheduleId}`;
+};
+
+export const getTotalSeatsCountKey = (scheduleId: number): string => {
+	return `total_seats_count:schedule:${scheduleId}`;
+};
+
+export const getBookedCountKey = (scheduleId: number): string => {
+	return `booked_count:schedule:${scheduleId}`;
+};
+
 // 분산락 관련
 export const getSeatLockKey = (seatId: number): string => {
 	return `seat:${seatId}`;

--- a/src/common/utils/redis-keys.ts
+++ b/src/common/utils/redis-keys.ts
@@ -1,4 +1,4 @@
-// sorted set 관련
+// sorted set 1) 랭킹시스템 관련
 export const getDurationKey = (scheduleId: number): string => {
 	return `schedule:${scheduleId}`;
 };
@@ -17,6 +17,19 @@ export const getTotalSeatsCountKey = (scheduleId: number): string => {
 
 export const getBookedCountKey = (scheduleId: number): string => {
 	return `booked_count:schedule:${scheduleId}`;
+};
+
+// sorted set 2) 대기열 관련
+export const waitingQueueKey = (): string => {
+	return 'waiting_queue';
+};
+
+export const activeQueueKey = (): string => {
+	return 'active_queue';
+};
+
+export const maxActiveUsersCountKey = (): string => {
+	return 'max_active_users_count';
 };
 
 // 분산락 관련

--- a/src/ticketing/application/domain/models/reservation.ts
+++ b/src/ticketing/application/domain/models/reservation.ts
@@ -13,6 +13,7 @@ export interface ReservationProps {
 	status?: ReservationStatus;
 	paidAt?: optional<Date>;
 	createdAt?: optional<Date>;
+	updatedAt?: optional<Date>;
 }
 
 export class Reservation {
@@ -23,6 +24,7 @@ export class Reservation {
 	status: ReservationStatus;
 	paidAt: optional<Date>;
 	createdAt: optional<Date>;
+	updatedAt: optional<Date>;
 
 	constructor({
 		id,
@@ -40,6 +42,7 @@ export class Reservation {
 		this.purchasePrice = purchasePrice;
 		this.paidAt = paidAt; // nullable
 		this.createdAt = createdAt ?? new Date();
+		this.updatedAt = createdAt ?? new Date();
 	}
 
 	setConfirmed(): void {

--- a/src/ticketing/application/domain/repositories/iconcert.repository.ts
+++ b/src/ticketing/application/domain/repositories/iconcert.repository.ts
@@ -5,6 +5,8 @@ import { Seat } from '../models/seat';
 export interface IConcertRepository {
 	findConcerts(): Promise<Concert[]>;
 	findSchedules(concertId: number): Promise<ConcertSchedule[]>;
+	findOneSchedule(scheduleId: number): Promise<ConcertSchedule>;
+	findManySchedules(scheduleIds: number[]): Promise<ConcertSchedule[]>;
 	findSeats(scheduleId: number): Promise<Seat[]>;
 	createConcert(concert: Concert): Promise<Concert>;
 	createSchedule(schedule: ConcertSchedule): Promise<ConcertSchedule>;

--- a/src/ticketing/application/services/event-search.service.ts
+++ b/src/ticketing/application/services/event-search.service.ts
@@ -14,8 +14,9 @@ import {
 } from '../../controllers/dtos/response.dto';
 import { Concert } from '../domain/models/concert';
 import { Seat } from '../domain/models/seat';
+import { TokenStatus } from '../domain/models/token';
 import { IConcertRepository } from '../domain/repositories/iconcert.repository';
-import { ITokenService } from './interfaces/itoken.service';
+import { QueueTokenService } from './queue-token.service';
 
 @Injectable()
 export class EventSearchService {
@@ -23,7 +24,7 @@ export class EventSearchService {
 		@Inject('IConcertRepository')
 		private readonly concertRepository: IConcertRepository,
 		@Inject('QueueTokenService')
-		private readonly tokenService: ITokenService,
+		private readonly tokenService: QueueTokenService,
 		private readonly redisService: RedisService,
 	) {}
 
@@ -39,6 +40,7 @@ export class EventSearchService {
 		const isValidToken = await this.tokenService.verifyToken(
 			userId,
 			queueToken,
+			TokenStatus.PROCESSING,
 		);
 		if (!isValidToken) {
 			throw new BadRequestException('Invalid token');
@@ -78,6 +80,7 @@ export class EventSearchService {
 		const isValidToken = await this.tokenService.verifyToken(
 			userId,
 			queueToken,
+			TokenStatus.PROCESSING,
 		);
 		if (!isValidToken) {
 			throw new BadRequestException('Invalid token');

--- a/src/ticketing/application/services/interfaces/itoken.service.ts
+++ b/src/ticketing/application/services/interfaces/itoken.service.ts
@@ -1,4 +1,5 @@
 import { ITokenResponseDto } from 'src/ticketing/controllers/dtos/response.dto';
+import { TokenStatus } from '../../domain/models/token';
 
 export interface ICreateQueueTokenParams {
 	userId: number;
@@ -16,6 +17,10 @@ export type CreateTokenParams =
 
 export interface ITokenService {
 	createToken(params: CreateTokenParams): Promise<ITokenResponseDto>;
-	verifyToken(userId: number, token: string): Promise<boolean>;
+	verifyToken(
+		userId: number,
+		token: string,
+		neededStatus: TokenStatus,
+	): Promise<boolean>;
 	deleteToken(key: string): Promise<boolean>;
 }

--- a/src/ticketing/application/services/payment-token.service.ts
+++ b/src/ticketing/application/services/payment-token.service.ts
@@ -54,6 +54,7 @@ export class PaymentTokenService implements ITokenService {
 		if (!tokenStatus) {
 			return false;
 		}
+		console.log('tokenStatus', tokenStatus);
 
 		const payload = await this.jwtService.verifyJwtAsync(token);
 

--- a/src/ticketing/application/services/payment-token.service.ts
+++ b/src/ticketing/application/services/payment-token.service.ts
@@ -47,21 +47,24 @@ export class PaymentTokenService implements ITokenService {
 		return { token };
 	}
 
-	async verifyToken(userId: number, token: string): Promise<boolean> {
+	async verifyToken(
+		userId: number,
+		token: string,
+		neededStatus: TokenStatus,
+	): Promise<boolean> {
 		// check expired
 		const cacheKey = getPaymentTokenKey(token);
 		const tokenStatus = await this.redisService.get(cacheKey);
 		if (!tokenStatus) {
 			return false;
 		}
-		console.log('tokenStatus', tokenStatus);
 
 		const payload = await this.jwtService.verifyJwtAsync(token);
 
 		if (
 			payload.userId !== userId ||
 			payload.purpose !== TokenPurpose.PAYMENT ||
-			tokenStatus !== TokenStatus.WAITING // 결제 대기
+			tokenStatus !== neededStatus // WAITING 임시결제토큰
 		) {
 			return false;
 		}

--- a/src/ticketing/application/services/queue-ranking.service.ts
+++ b/src/ticketing/application/services/queue-ranking.service.ts
@@ -1,0 +1,106 @@
+import {
+	BadRequestException,
+	Inject,
+	Injectable,
+	Logger,
+} from '@nestjs/common';
+import { RedisService } from 'src/common/services/redis/redis.service';
+import {
+	activeQueueKey,
+	getBookedCountKey,
+	getDurationKey,
+	getFastSelloutRankingKey,
+	getSellingStartTimeKey,
+	getTotalSeatsCountKey,
+	maxActiveUsersCountKey,
+	maxActiveUsersKey,
+	waitingQueueKey,
+} from 'src/common/utils/redis-keys';
+import {
+	FastSelloutRankingItem,
+	FastSelloutRankingResponseDto,
+} from 'src/ticketing/controllers/dtos/response.dto';
+import { IConcertRepository } from '../domain/repositories/iconcert.repository';
+
+@Injectable()
+export class QueueRankingService {
+	private readonly logger = new Logger(QueueRankingService.name);
+
+	constructor(private readonly redisService: RedisService) {}
+
+	async initialize(): Promise<void> {
+		await this.redisService.delete(waitingQueueKey());
+		await this.redisService.delete(activeQueueKey());
+		await this.redisService.set(maxActiveUsersKey(), 10); // 동시접속 10명
+	}
+
+	/**
+	 * create token 요청
+	 * - zadd waitQueue timestamp token
+	 */
+	async addToWaitingQueue(queueToken: string): Promise<void> {
+		try {
+			await this.redisService.zadd(waitingQueueKey(), Date.now(), queueToken);
+		} catch (error) {
+			this.logger.error(error);
+			throw new Error('FAILED_TO_UPDATE_RANKING');
+		}
+	}
+
+	/**
+	 * Queue 업데이트: max count만큼 찰 때까지 waiting -> active로 전환
+	 */
+	async updateEntireQueue(): Promise<void> {
+		const maxCount = Number(
+			await this.redisService.get(maxActiveUsersCountKey()),
+		);
+		let activeCount = Number(await this.redisService.zcard(activeQueueKey()));
+		let waitingCount = Number(await this.redisService.zcard(waitingQueueKey()));
+		while (activeCount < maxCount && waitingCount > 0) {
+			// waiting queue의 1순위를 active queue로 전환
+			const token = await this.redisService.zrange(waitingQueueKey(), 0, 0)[0];
+			this.logger.log('1st rank token: ', token.slice(0, 10));
+			await this.redisService.zrem(waitingQueueKey(), token);
+			await this.redisService.zadd(activeQueueKey(), Date.now(), token);
+			// update count
+			activeCount = Number(await this.redisService.zcard(activeQueueKey()));
+			waitingCount = Number(await this.redisService.zcard(waitingQueueKey()));
+		}
+	}
+
+	/** 대기 순번 확인 폴링시 호출
+	 * 	- 토큰이 waitingQueue에 있으면 남은 대기순번 반환
+	 * 	- 토큰이 activeQueue에 있으면 남은 예약시간 반환
+	 */
+	async checkQueueStatus(
+		token: string,
+	): Promise<{ waitingRank: number; activeRemainTime: number }> {
+		const result = {
+			waitingRank: -1,
+			activeRemainTime: -1,
+		};
+
+		const waitingScore = await this.redisService.zscore(
+			waitingQueueKey(),
+			token,
+		);
+		if (waitingScore !== -1) {
+			// 남은 대기순번 확인
+			const rank = await this.redisService.zrank(waitingQueueKey(), token);
+			result.waitingRank = rank;
+			return result;
+		}
+		const activeScore = await this.redisService.zscore(activeQueueKey(), token); // activeQueue로 전환된 시점 timestamp
+		if (activeScore !== -1) {
+			// 남은 예약시간 확인(제한 3분)
+			const expireTime = activeScore + 180000; // 1000 * 60 * 3
+			const remainingTime = expireTime - Date.now();
+			if (remainingTime > 0) {
+				result.activeRemainTime = remainingTime;
+				return result;
+			}
+		}
+		// 둘 다 없으면 권한 X
+		return result;
+	}
+}

--- a/src/ticketing/application/services/queue-token.service.int.spec.ts
+++ b/src/ticketing/application/services/queue-token.service.int.spec.ts
@@ -92,7 +92,11 @@ describe('QueueTokenService Integration Test', () => {
 			);
 
 			// when
-			const result = await queueTokenService.verifyToken(userId, queueToken);
+			const result = await queueTokenService.verifyToken(
+				userId,
+				queueToken,
+				TokenStatus.PROCESSING,
+			);
 
 			// then
 			expect(result).toBe(true);

--- a/src/ticketing/application/services/ranking.service.int.spec.ts
+++ b/src/ticketing/application/services/ranking.service.int.spec.ts
@@ -1,0 +1,221 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { IUserRepository } from 'src/auth/application/domain/repositories/iuser.repository';
+import { AuthModule } from 'src/auth/auth.module';
+import { CommonModule } from 'src/common/common.module';
+import { PrismaService } from 'src/common/services/prisma.service';
+import { RedisService } from 'src/common/services/redis/redis.service';
+import { REDIS_CLIENT, SEAT_EXPIRE_TTL } from 'src/common/utils/constants';
+import { PaymentService } from 'src/payment/application/services/payment.service';
+import { PaymentModule } from 'src/payment/payment.module';
+import { QueueModule } from 'src/queue/queue.module';
+import { QueueConsumer } from 'src/queue/services/queue-consumer.service';
+import { QueueProducer } from 'src/ticketing/infrastructure/external/queue-producer.service';
+import { ConcertPrismaRepository } from 'src/ticketing/infrastructure/persistence/concert.prisma.repository';
+import { ReservationPrismaRepository } from 'src/ticketing/infrastructure/persistence/reservation.prisma.repository';
+import { SeatPrismaRepository } from 'src/ticketing/infrastructure/persistence/seat.prisma.repository';
+import { TicketingModule } from 'src/ticketing/ticketing.module';
+import { TestDataFactory } from 'test/factories/test-data.factory';
+import { PrismaServiceRef } from 'test/prisma-test-setup';
+import { RedisClientRef } from 'test/redis-test-setup';
+import { TestWorkerSimulator } from 'test/utils/worker-simulator';
+import { ReservationExpireConsumer } from '../../../queue/services/reservation-expire-consumer.service';
+import { Concert } from '../domain/models/concert';
+import { Reservation, ReservationStatus } from '../domain/models/reservation';
+import { Seat, SeatStatus } from '../domain/models/seat';
+import { IConcertRepository } from '../domain/repositories/iconcert.repository';
+import { IReservationRepository } from '../domain/repositories/ireservation.repository';
+import { ISeatRepository } from '../domain/repositories/iseat.repository';
+import { ITokenService } from './interfaces/itoken.service';
+import { PaymentTokenService } from './payment-token.service';
+import { QueueTokenService } from './queue-token.service';
+import { RankingService } from './ranking.service';
+import { ReservationService } from './reservation.service';
+import { SeatLockService } from './seat-lock.service';
+
+describe('RankingService', () => {
+	let reservationService: ReservationService;
+	let rankingService: RankingService;
+	let userRepository: IUserRepository;
+	let concertRepository: IConcertRepository;
+	let seatRepository: ISeatRepository;
+	let reservationRepository: IReservationRepository;
+	let queueTokenService: QueueTokenService;
+	let paymentService: PaymentService;
+	let queueProducer: QueueProducer;
+	let queueConsumer: QueueConsumer;
+	let reservationExpireConsumer: ReservationExpireConsumer;
+	let seatLockService: SeatLockService;
+	let redisService: RedisService;
+	let paymentTokenService: PaymentTokenService;
+
+	beforeAll(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			imports: [CommonModule, AuthModule, PaymentModule, QueueModule],
+			providers: [
+				ReservationService,
+				RankingService,
+				{
+					provide: 'IConcertRepository',
+					useClass: ConcertPrismaRepository,
+				},
+				{
+					provide: 'ISeatRepository',
+					useClass: SeatPrismaRepository,
+				},
+				{
+					provide: 'IReservationRepository',
+					useClass: ReservationPrismaRepository,
+				},
+				{
+					provide: 'QueueTokenService',
+					useClass: QueueTokenService,
+				},
+				{
+					provide: 'PaymentTokenService',
+					useClass: PaymentTokenService,
+				},
+				QueueProducer,
+				QueueConsumer,
+				ReservationExpireConsumer,
+				SeatLockService,
+			],
+		})
+			.overrideProvider(PrismaService)
+			.useValue(PrismaServiceRef)
+			.overrideProvider(REDIS_CLIENT)
+			.useValue(RedisClientRef)
+			.compile();
+
+		reservationService = module.get<ReservationService>(ReservationService);
+		rankingService = module.get<RankingService>(RankingService);
+		userRepository = module.get<IUserRepository>('IUserRepository');
+		concertRepository = module.get<IConcertRepository>('IConcertRepository');
+		seatRepository = module.get<ISeatRepository>('ISeatRepository');
+		reservationRepository = module.get<IReservationRepository>(
+			'IReservationRepository',
+		);
+		paymentService = module.get<PaymentService>(PaymentService);
+		queueTokenService = module.get<QueueTokenService>('QueueTokenService');
+		queueProducer = module.get<QueueProducer>(QueueProducer);
+		queueConsumer = module.get<QueueConsumer>(QueueConsumer);
+		reservationExpireConsumer = module.get<ReservationExpireConsumer>(
+			ReservationExpireConsumer,
+		);
+		seatLockService = module.get<SeatLockService>(SeatLockService);
+		redisService = module.get(RedisService);
+		paymentTokenService = module.get('PaymentTokenService');
+	});
+
+	const numSchedules = 3;
+	const numEachSeats = 10;
+	const numUsers = numSchedules * numEachSeats;
+	const scheduleIds: number[] = [];
+	const seatIds: number[] = [];
+	let concert: Concert;
+
+	beforeEach(async () => {
+		await redisService.flushDb();
+
+		jest.spyOn(paymentTokenService, 'verifyToken').mockResolvedValue(true);
+		jest.spyOn(paymentTokenService, 'deleteToken').mockResolvedValue(true);
+		jest
+			.spyOn(reservationService, '_confirmWithOptimisticLock')
+			.mockImplementation(async (reservationId: number) => {
+				//🟡🟡동적으로 mock 생성. 하나의 schedule에 대해서만 updateRanking이 호출되지 않도록
+				const seatId = reservationId;
+				const scheduleId = (reservationId % numSchedules) + 1;
+
+				const mockReservation = new Reservation({
+					id: reservationId,
+					userId: 1,
+					seatId,
+					status: ReservationStatus.CONFIRMED,
+					purchasePrice: 10000,
+					paidAt: new Date(),
+					createdAt: new Date(),
+					updatedAt: new Date(),
+				});
+				const mockSeat = new Seat({
+					id: seatId,
+					scheduleId, // 동적으로 바뀌어야함.
+					className: 'A',
+					price: 10000,
+					status: SeatStatus.RESERVED,
+				});
+				return {
+					reservation: mockReservation,
+					seat: mockSeat,
+				};
+			});
+		jest.spyOn(paymentService, 'use').mockResolvedValue({
+			balance: 5000,
+		});
+
+		// 데이터 채워넣기 ************************************
+		concert = await TestDataFactory.createConcert(concertRepository);
+		for (let i = 0; i < numSchedules; i++) {
+			const schedule = await TestDataFactory.createSchedule(
+				concert.id,
+				concertRepository,
+			);
+			scheduleIds.push(schedule.id);
+			for (let j = 0; j < numEachSeats; j++) {
+				const seat = await TestDataFactory.createSeat(
+					schedule.id,
+					seatRepository,
+				);
+				seatIds.push(seat.id);
+			}
+		}
+		console.log('scheduleIds', scheduleIds);
+		console.log('seatIds', seatIds);
+	});
+
+	it('좌석 매진시 랭킹이 정상적으로 기록된다.', async () => {
+		// given
+		// 판매 시작!
+		await rankingService.startToSell(scheduleIds);
+
+		// 예약 요청
+		for (let i = 0; i < numUsers; i++) {
+			const userId = i + 1;
+			const reservationId = i + 1;
+			const paymentToken = 'test';
+			await reservationService.confirmReservation(
+				userId,
+				reservationId,
+				paymentToken,
+			);
+		}
+
+		// 랭킹확인
+		const ranking = await rankingService.getFastSelloutRanking();
+		expect(ranking).toHaveLength(3);
+		expect(ranking[0].scheduleId).toBe(3);
+	});
+
+	it('랭킹을 조회한다.', async () => {
+		// given
+		jest
+			.spyOn(redisService, 'zrange')
+			.mockResolvedValue([
+				'schedule:3',
+				'305',
+				'schedule:2',
+				'341',
+				'schedule:1',
+				'405',
+			]);
+		jest.spyOn(redisService, 'get').mockImplementation((key: string) => {
+			if (key.startsWith('selling_start_time')) {
+				return Promise.resolve(1751670949527);
+			}
+			if (key.startsWith('total_seats_count')) {
+				return Promise.resolve(10);
+			}
+		});
+		const ranking = await rankingService.getFastSelloutRanking();
+		expect(ranking).toHaveLength(3);
+		expect(ranking[0].scheduleId).toBe(3);
+	});
+});

--- a/src/ticketing/application/services/ranking.service.ts
+++ b/src/ticketing/application/services/ranking.service.ts
@@ -1,0 +1,115 @@
+import {
+	BadRequestException,
+	Inject,
+	Injectable,
+	Logger,
+} from '@nestjs/common';
+import { RedisService } from 'src/common/services/redis/redis.service';
+import {
+	getBookedCountKey,
+	getDurationKey,
+	getFastSelloutRankingKey,
+	getSellingStartTimeKey,
+	getTotalSeatsCountKey,
+} from 'src/common/utils/redis-keys';
+import {
+	FastSelloutRankingItem,
+	FastSelloutRankingResponseDto,
+} from 'src/ticketing/controllers/dtos/response.dto';
+import { IConcertRepository } from '../domain/repositories/iconcert.repository';
+
+@Injectable()
+export class RankingService {
+	private readonly logger = new Logger(RankingService.name);
+
+	constructor(
+		@Inject('IConcertRepository')
+		private readonly concertRepository: IConcertRepository,
+		private readonly redisService: RedisService,
+	) {}
+
+	// Admin 기능
+	async startToSell(scheduleIds: number[]): Promise<boolean> {
+		const schedules =
+			await this.concertRepository.findManySchedules(scheduleIds);
+		if (schedules.length === 0) {
+			throw new BadRequestException('Schedule not found');
+		}
+
+		// 모든 schedule에 대해 redis에 booked, seats, sellingStartTime key를 set
+		for (const schedule of schedules) {
+			const scheduleId = schedule.id;
+			const seatsCountKey = getTotalSeatsCountKey(scheduleId);
+			const bookedCountKey = getBookedCountKey(scheduleId);
+			const sellingStartTimeKey = getSellingStartTimeKey(scheduleId);
+
+			await this.redisService.set(seatsCountKey, schedule.totalSeats);
+			await this.redisService.set(bookedCountKey, 0);
+			await this.redisService.set(
+				sellingStartTimeKey,
+				schedule.startAt.getTime(),
+			);
+		}
+		return true;
+	}
+
+	async updateRanking(scheduleId: number): Promise<void> {
+		try {
+			const seatsCountKey = getTotalSeatsCountKey(scheduleId);
+			const bookedCountKey = getBookedCountKey(scheduleId);
+			const sellingStartTimeKey = getSellingStartTimeKey(scheduleId);
+
+			await this.redisService.increment(bookedCountKey);
+
+			const bookedCount = await this.redisService.get(bookedCountKey);
+			const seatsCount = await this.redisService.get(seatsCountKey);
+			if (Number(bookedCount) >= Number(seatsCount)) {
+				const duration =
+					Date.now() - Number(await this.redisService.get(sellingStartTimeKey));
+				await this.redisService.zadd(
+					getFastSelloutRankingKey(),
+					duration,
+					getDurationKey(scheduleId),
+				);
+			}
+		} catch (error) {
+			this.logger.error(error);
+			throw new Error('FAILED_TO_UPDATE_RANKING');
+		}
+	}
+
+	async getFastSelloutRanking(): Promise<FastSelloutRankingResponseDto> {
+		const ranking = await this.redisService.zrange(
+			getFastSelloutRankingKey(),
+			0,
+			-1,
+			true,
+		);
+		console.log('ranking', ranking);
+
+		const result: FastSelloutRankingItem[] = [];
+		for (let i = 0; i < ranking.length; i += 2) {
+			const key = ranking[i];
+			const scheduleId = Number(key.split('schedule:')[1]);
+			const duration = Number(ranking[i + 1]);
+
+			const startTimeKey = getSellingStartTimeKey(scheduleId);
+			const startTime = Number(await this.redisService.get(startTimeKey));
+			const selloutTime = startTime + duration;
+			const seatsCountKey = getTotalSeatsCountKey(scheduleId);
+			const seatsCount = Number(await this.redisService.get(seatsCountKey));
+			result.push({
+				scheduleId,
+				startTime: new Date(startTime),
+				selloutTime: new Date(selloutTime),
+				duration,
+				seatsCount,
+			});
+		}
+		console.log('result', result);
+
+		return {
+			ranking: result,
+		};
+	}
+}

--- a/src/ticketing/application/services/reservation.service.ts
+++ b/src/ticketing/application/services/reservation.service.ts
@@ -24,7 +24,7 @@ import { Seat, SeatStatus } from '../domain/models/seat';
 import { IReservationRepository } from '../domain/repositories/ireservation.repository';
 import { ISeatRepository } from '../domain/repositories/iseat.repository';
 import { ITokenService } from './interfaces/itoken.service';
-import { RankingService } from './ranking.service';
+import { SelloutRankingService } from './sellout-ranking.service';
 
 @Injectable()
 export class ReservationService {
@@ -45,7 +45,7 @@ export class ReservationService {
 		@Inject(DISTRIBUTED_LOCK_SERVICE)
 		private readonly distributedLockService: IDistributedLockService,
 		private readonly redisService: RedisService,
-		private readonly rankingService: RankingService,
+		private readonly selloutRankingService: SelloutRankingService,
 	) {}
 
 	async temporaryReserve(
@@ -222,7 +222,7 @@ export class ReservationService {
 
 		// redis sorted set 업데이트: 🟡매진 확인 후 duration 기록
 		const scheduleId = seat.scheduleId;
-		await this.rankingService.updateRanking(scheduleId);
+		await this.selloutRankingService.updateRanking(scheduleId);
 
 		return {
 			reservation: {

--- a/src/ticketing/application/services/sellout-ranking.service.int.spec.ts
+++ b/src/ticketing/application/services/sellout-ranking.service.int.spec.ts
@@ -28,9 +28,9 @@ import { ISeatRepository } from '../domain/repositories/iseat.repository';
 import { ITokenService } from './interfaces/itoken.service';
 import { PaymentTokenService } from './payment-token.service';
 import { QueueTokenService } from './queue-token.service';
-import { RankingService } from './ranking.service';
 import { ReservationService } from './reservation.service';
 import { SeatLockService } from './seat-lock.service';
+import { RankingService } from './sellout-ranking.service';
 
 describe('RankingService', () => {
 	let reservationService: ReservationService;

--- a/src/ticketing/application/services/sellout-ranking.service.int.spec.ts
+++ b/src/ticketing/application/services/sellout-ranking.service.int.spec.ts
@@ -30,11 +30,11 @@ import { PaymentTokenService } from './payment-token.service';
 import { QueueTokenService } from './queue-token.service';
 import { ReservationService } from './reservation.service';
 import { SeatLockService } from './seat-lock.service';
-import { RankingService } from './sellout-ranking.service';
+import { SelloutRankingService } from './sellout-ranking.service';
 
 describe('RankingService', () => {
 	let reservationService: ReservationService;
-	let rankingService: RankingService;
+	let rankingService: SelloutRankingService;
 	let userRepository: IUserRepository;
 	let concertRepository: IConcertRepository;
 	let seatRepository: ISeatRepository;
@@ -53,7 +53,7 @@ describe('RankingService', () => {
 			imports: [CommonModule, AuthModule, PaymentModule, QueueModule],
 			providers: [
 				ReservationService,
-				RankingService,
+				SelloutRankingService,
 				{
 					provide: 'IConcertRepository',
 					useClass: ConcertPrismaRepository,
@@ -87,7 +87,7 @@ describe('RankingService', () => {
 			.compile();
 
 		reservationService = module.get<ReservationService>(ReservationService);
-		rankingService = module.get<RankingService>(RankingService);
+		rankingService = module.get<SelloutRankingService>(SelloutRankingService);
 		userRepository = module.get<IUserRepository>('IUserRepository');
 		concertRepository = module.get<IConcertRepository>('IConcertRepository');
 		seatRepository = module.get<ISeatRepository>('ISeatRepository');

--- a/src/ticketing/application/services/sellout-ranking.service.ts
+++ b/src/ticketing/application/services/sellout-ranking.service.ts
@@ -19,8 +19,8 @@ import {
 import { IConcertRepository } from '../domain/repositories/iconcert.repository';
 
 @Injectable()
-export class RankingService {
-	private readonly logger = new Logger(RankingService.name);
+export class SelloutRankingService {
+	private readonly logger = new Logger(SelloutRankingService.name);
 
 	constructor(
 		@Inject('IConcertRepository')

--- a/src/ticketing/controllers/dtos/response.dto.ts
+++ b/src/ticketing/controllers/dtos/response.dto.ts
@@ -161,3 +161,29 @@ export class ConcertSeatResponseDto {
 	})
 	seats: Record<number, ConcertSeatItem>;
 }
+
+export class FastSelloutRankingItem {
+	scheduleId: number;
+	startTime: Date;
+	selloutTime: Date;
+	duration: number;
+	seatsCount: number;
+}
+
+// swagger로
+export class FastSelloutRankingResponseDto {
+	@ApiProperty({
+		type: [FastSelloutRankingItem],
+		description: '빠른 매진 랭킹 리스트',
+		example: [
+			{
+				scheduleId: 1,
+				startTime: new Date('2025-06-01T19:00:00.000Z'),
+				selloutTime: new Date('2025-06-01T21:00:00.000Z'),
+				duration: 120,
+				seatsCount: 50,
+			},
+		],
+	})
+	ranking: FastSelloutRankingItem[];
+}

--- a/src/ticketing/controllers/ranking.controller.ts
+++ b/src/ticketing/controllers/ranking.controller.ts
@@ -1,14 +1,14 @@
 import { Controller, Get, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiOkResponse, ApiOperation } from '@nestjs/swagger';
 import { AuthGuard } from '../../auth/application/services/auth.guard';
-import { RankingService } from '../application/services/ranking.service';
+import { SelloutRankingService } from '../application/services/sellout-ranking.service';
 import { FastSelloutRankingResponseDto } from './dtos/response.dto';
 
 @ApiBearerAuth()
 @UseGuards(AuthGuard)
 @Controller('/ticketing/ranking')
 export class RankingController {
-	constructor(private readonly rankingService: RankingService) {}
+	constructor(private readonly selloutRankingService: SelloutRankingService) {}
 
 	// 빠른예약 랭킹 조회
 	@Get('/ranking/fast-sellout')
@@ -18,6 +18,6 @@ export class RankingController {
 		description: '빠른예약 랭킹 조회 성공',
 	})
 	async fastSelloutRanking(): Promise<FastSelloutRankingResponseDto> {
-		return this.rankingService.getFastSelloutRanking();
+		return this.selloutRankingService.getFastSelloutRanking();
 	}
 }

--- a/src/ticketing/controllers/ranking.controller.ts
+++ b/src/ticketing/controllers/ranking.controller.ts
@@ -1,0 +1,23 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOkResponse, ApiOperation } from '@nestjs/swagger';
+import { AuthGuard } from '../../auth/application/services/auth.guard';
+import { RankingService } from '../application/services/ranking.service';
+import { FastSelloutRankingResponseDto } from './dtos/response.dto';
+
+@ApiBearerAuth()
+@UseGuards(AuthGuard)
+@Controller('/ticketing/ranking')
+export class RankingController {
+	constructor(private readonly rankingService: RankingService) {}
+
+	// 빠른예약 랭킹 조회
+	@Get('/ranking/fast-sellout')
+	@ApiOperation({ summary: '빠른예약 랭킹 조회' })
+	@ApiOkResponse({
+		type: FastSelloutRankingResponseDto,
+		description: '빠른예약 랭킹 조회 성공',
+	})
+	async fastSelloutRanking(): Promise<FastSelloutRankingResponseDto> {
+		return this.rankingService.getFastSelloutRanking();
+	}
+}

--- a/src/ticketing/controllers/reservation.controller.ts
+++ b/src/ticketing/controllers/reservation.controller.ts
@@ -14,6 +14,7 @@ import { Request } from 'express';
 import { AuthGuard } from '../../auth/application/services/auth.guard';
 import { Reservation } from '../application/domain/models/reservation';
 import { ITokenService } from '../application/services/interfaces/itoken.service';
+import { QueueTokenService } from '../application/services/queue-token.service';
 import { ReservationService } from '../application/services/reservation.service';
 import {
 	PaymentRequestDto,
@@ -33,7 +34,7 @@ export class ReservationController {
 	constructor(
 		private readonly reservationService: ReservationService,
 		@Inject('QueueTokenService')
-		private readonly tokenService: ITokenService,
+		private readonly tokenService: QueueTokenService,
 	) {}
 
 	// 대기열 토큰발급 (TTL 1시간)

--- a/src/ticketing/infrastructure/persistence/concert.prisma.repository.ts
+++ b/src/ticketing/infrastructure/persistence/concert.prisma.repository.ts
@@ -27,6 +27,26 @@ export class ConcertPrismaRepository implements IConcertRepository {
 		return entities.map((entity) => new ConcertSchedule(entity));
 	}
 
+	async findOneSchedule(scheduleId: number): Promise<ConcertSchedule> {
+		const entity = await this.txHost.tx.concertScheduleEntity.findUnique({
+			where: {
+				id: scheduleId,
+			},
+		});
+		return new ConcertSchedule(entity);
+	}
+
+	async findManySchedules(scheduleIds: number[]): Promise<ConcertSchedule[]> {
+		const entities = await this.txHost.tx.concertScheduleEntity.findMany({
+			where: {
+				id: {
+					in: scheduleIds,
+				},
+			},
+		});
+		return entities.map((entity) => new ConcertSchedule(entity));
+	}
+
 	async findSeats(scheduleId: number): Promise<Seat[]> {
 		const entities = await this.txHost.tx.seatEntity.findMany({
 			where: {

--- a/src/ticketing/ticketing.module.ts
+++ b/src/ticketing/ticketing.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { PaymentModule } from '../payment/payment.module';
 import { EventSearchService } from './application/services/event-search.service';
 import { PaymentTokenService } from './application/services/payment-token.service';
+import { QueueRankingService } from './application/services/queue-ranking.service';
 import { QueueTokenService } from './application/services/queue-token.service';
 import { ReservationService } from './application/services/reservation.service';
 import { SeatLockService } from './application/services/seat-lock.service';
@@ -21,6 +22,7 @@ import { SeatPrismaRepository } from './infrastructure/persistence/seat.prisma.r
 		ReservationService,
 		SeatLockService,
 		SelloutRankingService,
+		QueueRankingService,
 		{ provide: 'QueueTokenService', useClass: QueueTokenService },
 		{ provide: 'PaymentTokenService', useClass: PaymentTokenService },
 		{ provide: 'IConcertRepository', useClass: ConcertPrismaRepository },

--- a/src/ticketing/ticketing.module.ts
+++ b/src/ticketing/ticketing.module.ts
@@ -3,9 +3,11 @@ import { PaymentModule } from '../payment/payment.module';
 import { EventSearchService } from './application/services/event-search.service';
 import { PaymentTokenService } from './application/services/payment-token.service';
 import { QueueTokenService } from './application/services/queue-token.service';
+import { RankingService } from './application/services/ranking.service';
 import { ReservationService } from './application/services/reservation.service';
 import { SeatLockService } from './application/services/seat-lock.service';
 import { EventSearchController } from './controllers/event-search.controller';
+import { RankingController } from './controllers/ranking.controller';
 import { ReservationController } from './controllers/reservation.controller';
 import { QueueProducer } from './infrastructure/external/queue-producer.service';
 import { ConcertPrismaRepository } from './infrastructure/persistence/concert.prisma.repository';
@@ -18,6 +20,7 @@ import { SeatPrismaRepository } from './infrastructure/persistence/seat.prisma.r
 		EventSearchService,
 		ReservationService,
 		SeatLockService,
+		RankingService,
 		{ provide: 'QueueTokenService', useClass: QueueTokenService },
 		{ provide: 'PaymentTokenService', useClass: PaymentTokenService },
 		{ provide: 'IConcertRepository', useClass: ConcertPrismaRepository },
@@ -28,7 +31,11 @@ import { SeatPrismaRepository } from './infrastructure/persistence/seat.prisma.r
 		},
 		QueueProducer,
 	],
-	controllers: [EventSearchController, ReservationController],
+	controllers: [
+		EventSearchController,
+		ReservationController,
+		RankingController,
+	],
 	exports: [
 		SeatLockService,
 		{

--- a/src/ticketing/ticketing.module.ts
+++ b/src/ticketing/ticketing.module.ts
@@ -3,9 +3,9 @@ import { PaymentModule } from '../payment/payment.module';
 import { EventSearchService } from './application/services/event-search.service';
 import { PaymentTokenService } from './application/services/payment-token.service';
 import { QueueTokenService } from './application/services/queue-token.service';
-import { RankingService } from './application/services/ranking.service';
 import { ReservationService } from './application/services/reservation.service';
 import { SeatLockService } from './application/services/seat-lock.service';
+import { SelloutRankingService } from './application/services/sellout-ranking.service';
 import { EventSearchController } from './controllers/event-search.controller';
 import { RankingController } from './controllers/ranking.controller';
 import { ReservationController } from './controllers/reservation.controller';
@@ -20,7 +20,7 @@ import { SeatPrismaRepository } from './infrastructure/persistence/seat.prisma.r
 		EventSearchService,
 		ReservationService,
 		SeatLockService,
-		RankingService,
+		SelloutRankingService,
 		{ provide: 'QueueTokenService', useClass: QueueTokenService },
 		{ provide: 'PaymentTokenService', useClass: PaymentTokenService },
 		{ provide: 'IConcertRepository', useClass: ConcertPrismaRepository },


### PR DESCRIPTION
### **커밋 설명**

- 빠른매진 랭킹 시스템 : f2bf635 
- 대기열 토큰 sorted set 추가 : ee71e81

---
### **리뷰 받고 싶은 내용(질문)**
#### 1. 빠른매진 랭킹 테스트
커밋 : f2bf635 
- 레디스 연산을 주로 사용하다보니 유닛테스트에 어려움을 느끼고 통합테스트로 진행하였는데, 어쩔 수 없는 부분일까요?
콘서트 판매 시작시 start time, seat count 등 초기화 등 셋팅이 되려면 유닛테스트는 어려운 것 같습니다.
실무에서 레디스 연산을 쓰는 경우 어떤식으로 테스트를 작성하시는지 궁금합니다. 
- 현재 구현: duration을 기준으로 랭킹
  - 각 scheduleId에 대해 판매 시작시 start time, 총 좌석수 기록
  - 최종 예약이 발생할 때마다 booked count++, 매진이 된 경우 sorted set에 duration 기록
  - duration 오름차순 = 빠른매진 랭킹

#### 2. 대기열 관리: 언제 대기중인 유저를 active로 전환할 것인가?
커밋: ee71e81
- 현재 유저가 예약 요청을 할 때마다 전체 큐를 업데이트(waiting -> active 전환)하고 있는데,  
별도의 폴링이나 배치에서 큐 상태를 업데이트하는 것이 나을까요?
- 동시예약 요청시 부하가 클 것으로 예상. 다만 분산락을 걸어두고 그 안에서 처리하면 괜찮을 수도?
- 유저가 active로 전환된 것을 확인 후 예약을 진행해야하는데, 배치로 할 경우 불일치가 발생하지 않을까요?
- 실무에서 큐를 언제, 어떤식으로 업데이트하는지 best practice가 궁금합니다.

![image](https://github.com/user-attachments/assets/0c3f65ca-8899-4b73-bcf0-ca833e0ecfce)

```typescript
// 임시 좌석배정
async temporaryReserve(
    userId: number,
    seatId: number,
    queueToken: string,
): Promise<ReserveResponseDto> {
    try {
        // 전체 큐 업데이트
        await this.queueRankingService.updateEntireQueue();
        // 해당 유저 토큰 확인
        const isValidToken = await this.queueTokenService.verifyToken(
            userId,
            queueToken,
            TokenStatus.PROCESSING, // 예약페이지 접속한 사람만 예약할 수 있음
        );

/**
 * Queue 업데이트: max count만큼 찰 때까지 waiting -> active로 전환
 */
async updateEntireQueue(): Promise<void> {
	const maxCount = Number(
		await this.redisService.get(maxActiveUsersCountKey()),
	);
	let activeCount = Number(await this.redisService.zcard(activeQueueKey()));
	let waitingCount = Number(await this.redisService.zcard(waitingQueueKey()));
	while (activeCount < maxCount && waitingCount > 0) {
		// waiting queue의 1순위를 active queue로 전환
		const token = await this.redisService.zrange(waitingQueueKey(), 0, 0)[0];
		this.logger.log('1st rank token: ', token.slice(0, 10));
		await this.redisService.zrem(waitingQueueKey(), token);
		await this.redisService.zadd(activeQueueKey(), Date.now(), token);
		// update count
		activeCount = Number(await this.redisService.zcard(activeQueueKey()));
		waitingCount = Number(await this.redisService.zcard(waitingQueueKey()));
	}
}

/** 대기 순번 확인 폴링시 호출
 * 토큰이 waitingQueue에 있으면 남은 대기순번 반환
 * 토큰이 activeQueue에 있으면 남은 예약시간 반환
 */
async checkQueueStatus(
    token: string,
): Promise<{ waitingRank: number; activeRemainTime: number }> {
    const result = {
        waitingRank: -1,
        activeRemainTime: -1,
    };

    const waitingScore = await this.redisService.zscore(
        waitingQueueKey(),
        token,
    );
    if (waitingScore !== -1) {
        // 남은 대기순번 확인
        const rank = await this.redisService.zrank(waitingQueueKey(), token);
        result.waitingRank = rank;
        return result;
    }
    const activeScore = await this.redisService.zscore(activeQueueKey(), token); // activeQueue로 전환된 시점 timestamp
    if (activeScore !== -1) {
        // 남은 예약시간 확인(제한 3분)
        const expireTime = activeScore + 180000; // 1000 * 60 * 3
        const remainingTime = expireTime - Date.now();
        if (remainingTime > 0) {
            result.activeRemainTime = remainingTime;
            return result;
        }
    }
    // 둘 다 없으면 권한 X
    return result;
}

// 어떤 sorted set에 있는지 여부로 검증
async verifyToken(
    userId: number,
    token: string,
    neededStatus: TokenStatus,
): Promise<boolean> {
    // check sorted set: waitingQueue에 있으면 true
    const queueStatus = await this.queueRankingService.checkQueueStatus(token);
    if (
        neededStatus === TokenStatus.WAITING && queueStatus.waitingRank === -1
    ) {
        return false;
    }
    if (
        neededStatus === TokenStatus.PROCESSING && queueStatus.activeRemainTime === -1
    ) {
        return false;
    }

    const payload = await this.jwtService.verifyJwtAsync(token);

    if (payload.userId !== userId) {
        return false;
    }

    return true;
}
```

---  
### **과제 셀프 피드백**
- 기존에 대기열을 BullMQ로 관리하던 것을 sorted set으로 관리하면서 훨씬 간결해짐. 동시접속자 수백명을 가정할때도 어려움이 없어짐.