### PR TITLE
Week8: 이벤트 기반 구조 설계

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,8 @@ lerna-debug.log*
 
 /generated/prisma
 
+# temp
 docs/cache-strategy.md
+sample.py
+queue-ranking.service.int.spec.ts
+sellout-ranking.service.e2e.spec.ts

--- a/docs/msa-design.md
+++ b/docs/msa-design.md
@@ -1,0 +1,413 @@
+# MSA 구조 설계 문서
+
+## 1. 현재 모놀리식 구조
+
+### 1.1 현재 아키텍처
+```
+Ticketing Monolith
+├── Auth Module (인증/인가)
+├── Ticketing Module (대기열/좌석/예약)
+├── Payment Module (결제/잔액조회)
+└── DataPlatform Module (예약현황 로그 전송)
+```
+
+### 1.2 현재 이벤트 흐름
+```
+임시예약 → 결제 → 예약확정 → 데이터플랫폼 전송
+```
+
+## 2. MSA 도메인 분리 설계
+
+### 2.1 배포 단위별 도메인 분리
+
+#### **Auth Service** 🔐
+- **책임**: 사용자 인증, 인가, JWT 토큰 관리
+- **데이터**: User, Role, Permission
+- **API**: `/auth/signup`, `/auth/login`
+
+#### **Queue Service** 🚦
+- **책임**: 대기열 관리, 토큰 발급/검증
+- **데이터**: QueueToken, WaitingQueue, ActiveQueue
+- **API**: `/queue/token`, `/queue/status`
+
+#### **Concert Service** 🎵
+- **책임**: 콘서트, 스케줄, 좌석 관리
+- **데이터**: Concert, Schedule, Seat
+- **API**: `/ticketing/search/concerts/{id}/schedules`, `/ticketing/search/schedules/{scheduleId}/seats`
+
+#### **Reservation Service** 🎫
+- **책임**: 임시 예약 생성, 최종 예약, 예약 상태 조회
+- **데이터**: Reservation
+- **API**: `/ticketing/reservations/new`, `/ticketing/reservations/confirm`, `/ticketing/reservations/{id}`
+
+#### **Payment Service** 💳
+- **책임**: 포인트 충전, 결제 처리, 잔액 조회 
+- **데이터**: Payment, Balance, PaymentHistory
+- **API**: `/payments/charge`, `/payments/process`, `/balance`
+
+#### **DataPlatform Service** 📊
+- **책임**: 예약 이벤트 로그 수집 및 분석
+- **데이터**: Reservation
+- **API**: `/data-platform/reservations`
+
+---
+### 2.2 MSA 아키텍처 다이어그램
+
+```mermaid
+graph TB
+    Client[Client Application]
+    
+    subgraph "API Gateway"
+        Gateway[API Gateway/Load Balancer]
+    end
+    
+    subgraph "Core Services"
+        Auth[Auth Service]
+        Queue[Queue Service]
+        Concert[Concert Service]
+        Reservation[Reservation Service]
+        Payment[Payment Service]
+    end
+    
+    subgraph "Supporting Services"
+        DataPlatform[DataPlatform Service]
+    end
+    
+    subgraph "Infrastructure"
+        EventBus[Event Bus/Message Queue]
+        AuthDB[(Auth DB)]
+        QueueDB[(Queue DB)]
+        ConcertDB[(Concert DB)]
+        ReservationDB[(Reservation DB)]
+        PaymentDB[(Payment DB)]
+        DataPlatformDB[(DataPlatform DB)]
+    end
+    
+    Client --> Gateway
+    Gateway --> Auth
+    Gateway --> Queue
+    Gateway --> Concert
+    Gateway --> Reservation
+    Gateway --> Payment
+    
+    Auth --> AuthDB
+    Queue --> QueueDB
+    Concert --> ConcertDB
+    Reservation --> ReservationDB
+    Payment --> PaymentDB
+    DataPlatform --> DataPlatformDB
+    
+    Reservation --> EventBus
+    Payment --> EventBus
+    EventBus --> DataPlatform
+```
+
+---
+## 3. 분산 트랜잭션 처리의 한계와 해결방안
+
+### 3.1 트랜잭션 처리의 한계
+
+#### **ACID 속성 보장의 어려움**
+- **원자성**: 여러 서비스에 걸친 트랜잭션의 All-or-Nothing 보장 불가
+- **일관성**: 서비스 간 데이터 일관성 유지 복잡
+- **격리성**: 분산 환경에서 동시성 제어 어려움
+- **지속성**: 네트워크 장애 시 데이터 손실 위험
+
+#### **구체적인 문제 시나리오**
+```
+1. 예약 생성 성공 → 결제 실패 → 예약 데이터 정리 필요
+2. 결제 성공 → 좌석 상태 업데이트 실패 → 결제 취소 필요
+3. 네트워크 장애로 인한 부분 실패 상황
+```
+
+---
+### 3.2 해결방안: Saga 패턴 적용
+
+#### **3.2.1 Choreography-based Saga (이벤트 기반)**
+
+**현재 구현된 방식**
+```typescript
+// 예약 흐름
+1. temporaryReserve() → 임시예약 생성
+2. processPayment() → 결제 처리 + payment.success 이벤트 발행
+3. PaymentEventListener → reservation.confirmReservation() 호출
+4. confirmReservation() → 예약 확정 + reservation.success 이벤트 발행
+```
+
+**보상 트랜잭션 구현**
+```typescript
+// ReservationService
+async confirmReservation(reservationId: number): Promise<void> {
+  try {
+    // 예약 확정 로직
+    await this.reservationRepository.updateStatus(reservationId, 'CONFIRMED');
+    await this.seatRepository.updateStatus(seatId, 'SOLD');
+    
+    // 성공 이벤트 발행
+    this.eventBus.emit('reservation.success', new ReservationSuccessEvent(...));
+  } catch (error) {
+    // 실패 시 보상 이벤트 발행
+    this.eventBus.emit('reservation.failed', new ReservationFailedEvent(reservationId));
+  }
+}
+
+// PaymentEventListener
+@OnEventSafe('reservation.failed')
+async onReservationFailed(event: ReservationFailedEvent): Promise<void> {
+  // 결제 취소 (보상 트랜잭션)
+  await this.paymentService.cancelPayment(event.paymentId);
+  this.eventBus.emit('payment.cancelled', new PaymentCancelledEvent(...));
+}
+```
+
+#### **3.2.2 Orchestration-based Saga (중앙 집중식)**
+
+**Reservation Saga Orchestrator 구현**
+```typescript
+@Injectable()
+export class ReservationSagaOrchestrator {
+  async executeReservationSaga(request: ReservationRequest): Promise<void> {
+    const sagaId = generateSagaId();
+    
+    try {
+      // Step 1: 임시 예약
+      const reservation = await this.reservationService.createTemporaryReservation(request);
+      
+      // Step 2: 결제 처리
+      const payment = await this.paymentService.processPayment({
+        userId: request.userId,
+        amount: request.amount,
+        reservationId: reservation.id
+      });
+      
+      // Step 3: 예약 확정
+      await this.reservationService.confirmReservation(reservation.id);
+      
+      // Step 4: 알림 발송
+      await this.notificationService.sendReservationConfirmation(request.userId);
+      
+    } catch (error) {
+      // 보상 트랜잭션 실행
+      await this.executeCompensation(sagaId, error);
+    }
+  }
+  
+  private async executeCompensation(sagaId: string, error: Error): Promise<void> {
+    // 역순으로 보상 작업 실행
+    const sagaLog = await this.getSagaLog(sagaId);
+    
+    for (const step of sagaLog.completedSteps.reverse()) {
+      await this.executeCompensationStep(step);
+    }
+  }
+}
+```
+
+### 3.3 이벤트 기반 아키텍처 고도화
+
+#### **3.3.1 Event Sourcing 패턴**
+```typescript
+// 이벤트 저장소
+@Entity()
+export class EventStore {
+  @PrimaryGeneratedColumn()
+  id: number;
+  
+  @Column()
+  aggregateId: string;
+  
+  @Column()
+  eventType: string;
+  
+  @Column('json')
+  eventData: any;
+  
+  @Column()
+  version: number;
+  
+  @CreateDateColumn()
+  createdAt: Date;
+}
+
+// 이벤트 기반 예약 상태 관리
+export class ReservationAggregate {
+  private events: DomainEvent[] = [];
+  
+  createReservation(command: CreateReservationCommand): void {
+    const event = new ReservationCreatedEvent(command);
+    this.applyEvent(event);
+  }
+  
+  confirmReservation(): void {
+    if (this.status !== 'TEMPORARY') {
+      throw new Error('Cannot confirm non-temporary reservation');
+    }
+    
+    const event = new ReservationConfirmedEvent(this.id);
+    this.applyEvent(event);
+  }
+  
+  private applyEvent(event: DomainEvent): void {
+    this.events.push(event);
+    this.apply(event);
+  }
+}
+```
+
+#### **3.3.2 CQRS (Command Query Responsibility Segregation)**
+```typescript
+// Command Side
+@CommandHandler(CreateReservationCommand)
+export class CreateReservationHandler {
+  async execute(command: CreateReservationCommand): Promise<void> {
+    const aggregate = new ReservationAggregate();
+    aggregate.createReservation(command);
+    
+    await this.eventStore.save(aggregate.getUncommittedEvents());
+  }
+}
+
+// Query Side
+@QueryHandler(GetReservationQuery)
+export class GetReservationHandler {
+  async execute(query: GetReservationQuery): Promise<ReservationView> {
+    return await this.reservationViewRepository.findById(query.reservationId);
+  }
+}
+```
+
+## 4. 구현된 안전장치
+
+### 4.1 OnEventSafe 데코레이터
+```typescript
+@OnEventSafe('payment.success')
+async onPaymentSuccess(event: PaymentSuccessEvent): Promise<void> {
+  // 예외 발생 시 자동으로 로깅하고 다른 리스너에 영향 없음
+}
+```
+
+### 4.2 멱등성 보장
+```typescript
+@Injectable()
+export class IdempotentEventHandler {
+  private processedEvents = new Set<string>();
+  
+  @OnEventSafe('payment.success')
+  async handlePaymentSuccess(event: PaymentSuccessEvent): Promise<void> {
+    const eventKey = `${event.type}-${event.paymentId}-${event.timestamp}`;
+    
+    if (this.processedEvents.has(eventKey)) {
+      return; // 이미 처리된 이벤트
+    }
+    
+    await this.processEvent(event);
+    this.processedEvents.add(eventKey);
+  }
+}
+```
+
+### 4.3 재시도 메커니즘
+```typescript
+@Injectable()
+export class RetryableEventHandler {
+  @OnEventSafe('reservation.confirm')
+  @Retry({ attempts: 3, delay: 1000 })
+  async handleReservationConfirm(event: ReservationConfirmEvent): Promise<void> {
+    // 일시적 실패 시 자동 재시도
+  }
+}
+```
+
+## 5. 모니터링 및 운영
+
+### 5.1 분산 추적
+```typescript
+// Correlation ID를 통한 요청 추적
+export class CorrelationIdMiddleware {
+  use(req: Request, res: Response, next: NextFunction): void {
+    req.correlationId = req.headers['x-correlation-id'] || generateId();
+    res.setHeader('x-correlation-id', req.correlationId);
+    next();
+  }
+}
+```
+
+### 5.2 Circuit Breaker 패턴
+```typescript
+@Injectable()
+export class PaymentServiceClient {
+  @CircuitBreaker({ threshold: 5, timeout: 10000 })
+  async processPayment(request: PaymentRequest): Promise<PaymentResponse> {
+    // 외부 결제 서비스 호출
+    // 실패율이 임계값을 초과하면 Circuit Open
+  }
+}
+```
+
+## 6. 배포 및 확장성 고려사항
+
+### 6.1 데이터베이스 분리 전략
+- **Database per Service**: 각 서비스별 독립적인 데이터베이스
+- **Shared Database Anti-pattern 회피**
+- **데이터 동기화**: Event-driven 방식으로 필요한 데이터만 복제
+
+### 6.2 API Gateway 패턴
+- **라우팅**: 클라이언트 요청을 적절한 서비스로 라우팅
+- **인증/인가**: 중앙집중식 보안 처리
+- **Rate Limiting**: 서비스별 요청 제한
+- **로드 밸런싱**: 서비스 인스턴스 간 부하 분산
+
+### 6.3 서비스 디스커버리
+- **동적 서비스 등록/해제**
+- **헬스 체크**: 서비스 상태 모니터링
+- **로드 밸런싱**: 가용한 인스턴스로 요청 분산
+
+## 7. 결론
+
+현재 구현된 이벤트 기반 아키텍처는 MSA로의 전환을 위한 좋은 기반을 제공합니다. 
+
+**주요 장점:**
+- 서비스 간 느슨한 결합
+- 보상 트랜잭션을 통한 데이터 일관성 보장
+- 이벤트 기반 비동기 처리로 성능 향상
+- OnEventSafe 데코레이터를 통한 안정성 확보
+
+**향후 개선 방향:**
+- Saga Orchestrator 도입으로 복잡한 비즈니스 플로우 관리
+- Event Sourcing을 통한 완전한 감사 추적
+- CQRS 패턴으로 읽기/쓰기 성능 최적화
+- 분산 추적 시스템 도입으로 운영 가시성 확보
+
+
+
+<!-- 
+## 이벤트 기반 아키텍처 설계 기본개념
+### 1. 이벤트 발행 시점 결정 기준
+
+#### 1.1 비즈니스 이벤트 발행 시점
+- **트랜잭션 커밋 후**: 데이터 일관성이 보장된 후 이벤트 발행
+- **상태 변경 완료 후**: 도메인 객체의 상태가 완전히 변경된 후
+- **외부 의존성 호출 전**: 외부 API 호출 전에 내부 이벤트 먼저 처리
+
+#### 1.2 보상 이벤트 발행 시점
+- **실패 감지 즉시**: 비즈니스 로직 실패 시 즉시 보상 이벤트 발행
+- **타임아웃 발생 시**: 일정 시간 내 응답이 없을 때 보상 처리
+
+## 2. 이벤트 구독 위치 결정 기준
+
+### 2.1 도메인별 이벤트 리스너 배치
+```
+src/
+├── payment/
+│   └── infrastructure/
+│       └── event-listeners/
+│           └── payment-event.listener.ts    # 결제 관련 이벤트 처리
+├── ticketing/
+│   └── infrastructure/
+│       └── event-listeners/
+│           └── reservation-event.listener.ts # 예약 관련 이벤트 처리
+
+```
+### 2.2 이벤트 리스너 책임 분리
+- **단일 책임**: 하나의 리스너는 하나의 도메인 이벤트만 처리
+- **느슨한 결합**: 다른 도메인의 구현 세부사항에 의존하지 않음 -->

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^3.3.0",
     "@nestjs/core": "^10.0.0",
+    "@nestjs/event-emitter": "^3.0.1",
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/swagger": "^11.2.0",
     "@prisma/client": "6.8.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@nestjs/core':
         specifier: ^10.0.0
         version: 10.4.17(@nestjs/common@10.4.17(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.17)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/event-emitter':
+        specifier: ^3.0.1
+        version: 3.0.1(@nestjs/common@10.4.17(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.17)
       '@nestjs/platform-express':
         specifier: ^10.0.0
         version: 10.4.17(@nestjs/common@10.4.17(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.17)
@@ -679,6 +682,12 @@ packages:
         optional: true
       '@nestjs/websockets':
         optional: true
+
+  '@nestjs/event-emitter@3.0.1':
+    resolution: {integrity: sha512-0Ln/x+7xkU6AJFOcQI9tIhUMXVF7D5itiaQGOyJbXtlAfAIt8gzDdJm+Im7cFzKoWkiW5nCXCPh6GSvdQd/3Dw==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^10.0.0 || ^11.0.0
 
   '@nestjs/mapped-types@2.1.0':
     resolution: {integrity: sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==}
@@ -1851,6 +1860,9 @@ packages:
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
+
+  eventemitter2@6.4.9:
+    resolution: {integrity: sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==}
 
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
@@ -4264,6 +4276,12 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  '@nestjs/event-emitter@3.0.1(@nestjs/common@10.4.17(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.17)':
+    dependencies:
+      '@nestjs/common': 10.4.17(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 10.4.17(@nestjs/common@10.4.17(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.17)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      eventemitter2: 6.4.9
+
   '@nestjs/mapped-types@2.1.0(@nestjs/common@10.4.17(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)':
     dependencies:
       '@nestjs/common': 10.4.17(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -5579,6 +5597,8 @@ snapshots:
   etag@1.8.1: {}
 
   event-target-shim@5.0.1: {}
+
+  eventemitter2@6.4.9: {}
 
   events@3.3.0: {}
 

--- a/prisma/migrations/20250707125738_added_event_log/migration.sql
+++ b/prisma/migrations/20250707125738_added_event_log/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE `event_logs` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `event_name` VARCHAR(191) NOT NULL,
+    `timestamp` DATETIME(3) NOT NULL,
+    `data` JSON NOT NULL,
+    `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    INDEX `event_logs_event_name_idx`(`event_name`),
+    INDEX `event_logs_timestamp_idx`(`timestamp`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -107,3 +107,15 @@ model ReservationEntity {
   @@index([userId])
   @@map("reservations")
 }
+
+model EventLogEntity {
+  id        Int        @id @default(autoincrement())
+  eventName String     @map("event_name")
+  timestamp DateTime
+  data      Json
+  createdAt DateTime   @default(now()) @map("created_at")
+
+  @@index([eventName])
+  @@index([timestamp])
+  @@map("event_logs")
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,6 +4,7 @@ import { AuthModule } from './auth/auth.module';
 import { CommonModule } from './common/common.module';
 import { LoggerMiddleware } from './common/middlewares/logger.middleware';
 import { HttpExceptionFilter } from './common/services/exception.filter';
+import { DataPlatformModule } from './data-platform/data-platform.module';
 import { PaymentModule } from './payment/payment.module';
 import { QueueModule } from './queue/queue.module';
 import { TicketingModule } from './ticketing/ticketing.module';
@@ -15,6 +16,7 @@ import { TicketingModule } from './ticketing/ticketing.module';
 		TicketingModule,
 		QueueModule,
 		PaymentModule,
+		DataPlatformModule,
 	],
 	controllers: [],
 	providers: [

--- a/src/common/common.module.ts
+++ b/src/common/common.module.ts
@@ -1,12 +1,18 @@
 import { ClsPluginTransactional } from '@nestjs-cls/transactional';
 import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
 import { Global, Module } from '@nestjs/common';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 import { Redis } from 'ioredis';
 import { ClsModule } from 'nestjs-cls';
+import { NestEventBus } from './services/events/nest-event-bus';
 import { PrismaService } from './services/prisma.service';
 import { DistributedLockService } from './services/redis/distributed-lock.service';
 import { RedisService } from './services/redis/redis.service';
-import { DISTRIBUTED_LOCK_SERVICE, REDIS_CLIENT } from './utils/constants';
+import {
+	DISTRIBUTED_LOCK_SERVICE,
+	EVENT_BUS,
+	REDIS_CLIENT,
+} from './utils/constants';
 
 @Global()
 @Module({
@@ -20,6 +26,7 @@ import { DISTRIBUTED_LOCK_SERVICE, REDIS_CLIENT } from './utils/constants';
 				}),
 			],
 		}),
+		EventEmitterModule.forRoot(),
 	],
 	controllers: [],
 	providers: [
@@ -42,7 +49,11 @@ import { DISTRIBUTED_LOCK_SERVICE, REDIS_CLIENT } from './utils/constants';
 			provide: DISTRIBUTED_LOCK_SERVICE,
 			useClass: DistributedLockService,
 		},
+		{
+			provide: EVENT_BUS,
+			useClass: NestEventBus,
+		},
 	],
-	exports: [PrismaService, RedisService, DISTRIBUTED_LOCK_SERVICE],
+	exports: [PrismaService, RedisService, DISTRIBUTED_LOCK_SERVICE, EVENT_BUS],
 })
 export class CommonModule {}

--- a/src/common/decorators/on-event-safe.decorator.ts
+++ b/src/common/decorators/on-event-safe.decorator.ts
@@ -1,0 +1,39 @@
+// on-event-safe.decorator.ts
+import { Logger, applyDecorators } from '@nestjs/common';
+import { OnEvent, OnEventType } from '@nestjs/event-emitter';
+import { OnEventOptions } from '@nestjs/event-emitter/dist/interfaces';
+
+function _OnEventSafe(): MethodDecorator {
+	return <T>(
+		target: any,
+		key: string,
+		descriptor: PropertyDescriptor,
+	): TypedPropertyDescriptor<T> => {
+		const originalMethod = descriptor.value;
+
+		const metaKeys = Reflect.getOwnMetadataKeys(descriptor.value);
+		const metas = metaKeys.map((key) => [
+			key,
+			Reflect.getMetadata(key, descriptor.value),
+		]);
+
+		descriptor.value = async function (...args: any[]): Promise<void> {
+			try {
+				await originalMethod.call(this, ...args);
+			} catch (err) {
+				Logger.error(err, err.stack, 'OnEventSafe');
+			}
+		};
+		for (const [k, v] of metas) {
+			Reflect.defineMetadata(k, v, descriptor.value);
+		}
+		return descriptor;
+	};
+}
+
+export function OnEventSafe(
+	event: OnEventType,
+	options?: OnEventOptions | undefined,
+): MethodDecorator {
+	return applyDecorators(OnEvent(event, options), _OnEventSafe());
+}

--- a/src/common/interfaces/ievent-bus.interface.ts
+++ b/src/common/interfaces/ievent-bus.interface.ts
@@ -1,0 +1,15 @@
+export interface IEvent {
+	eventName: string;
+	timestamp: Date;
+	data: any;
+}
+
+export type EventHandler<T extends IEvent> = (event: T) => void;
+
+export interface IEventBus {
+	publish<T extends IEvent>(event: T): void;
+	subscribe<T extends IEvent>(
+		eventName: string,
+		listener: EventHandler<T>,
+	): void;
+}

--- a/src/common/services/events/nest-event-bus.ts
+++ b/src/common/services/events/nest-event-bus.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import {
+	EventHandler,
+	IEvent,
+	IEventBus,
+} from 'src/common/interfaces/ievent-bus.interface';
+
+@Injectable()
+export class NestEventBus implements IEventBus {
+	constructor(private readonly eventEmitter: EventEmitter2) {}
+
+	publish<T extends IEvent>(event: T): void {
+		this.eventEmitter.emit(event.eventName, event);
+	}
+
+	subscribe<T extends IEvent>(
+		eventName: string,
+		listener: EventHandler<T>,
+	): void {
+		this.eventEmitter.on(eventName, listener);
+	}
+}

--- a/src/common/utils/constants.ts
+++ b/src/common/utils/constants.ts
@@ -1,6 +1,7 @@
 // SERVICE INJECTION TOKEN
 export const REDIS_CLIENT = 'REDIS_CLIENT';
 export const DISTRIBUTED_LOCK_SERVICE = 'DISTRIBUTED_LOCK_SERVICE';
+export const EVENT_BUS = 'EVENT_BUS';
 
 // ======================= TTL (비즈니스 로직) =======================
 export const QUEUE_TOKEN_TTL = 3600; // 1h

--- a/src/data-platform/application/services/data-platform.service.ts
+++ b/src/data-platform/application/services/data-platform.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { IEvent } from 'src/common/interfaces/ievent-bus.interface';
+import { EventLogPrismaRepository } from 'src/data-platform/infrastructure/persistence/event-log.repository';
+
+@Injectable()
+export class DataPlatformService {
+	constructor(
+		private readonly eventLogPrismaRepository: EventLogPrismaRepository,
+	) {}
+	async send(event: IEvent): Promise<void> {
+		// 데이터분석 플랫폼에 전송
+		await this.eventLogPrismaRepository.create(
+			event.eventName,
+			event.timestamp,
+			event.data,
+		);
+		return;
+	}
+}

--- a/src/data-platform/data-platform.module.ts
+++ b/src/data-platform/data-platform.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { DataPlatformService } from './services/data-platform.service';
+
+@Module({
+	providers: [DataPlatformService],
+	exports: [DataPlatformService],
+})
+export class DataPlatformModule {}

--- a/src/data-platform/data-platform.module.ts
+++ b/src/data-platform/data-platform.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
-import { DataPlatformService } from './services/data-platform.service';
+import { DataPlatformService } from './application/services/data-platform.service';
+import { EventLogPrismaRepository } from './infrastructure/persistence/event-log.repository';
 
 @Module({
-	providers: [DataPlatformService],
-	exports: [DataPlatformService],
+	providers: [DataPlatformService, EventLogPrismaRepository],
+	exports: [DataPlatformService, EventLogPrismaRepository],
 })
 export class DataPlatformModule {}

--- a/src/data-platform/infrastructure/persistence/event-log.repository.ts
+++ b/src/data-platform/infrastructure/persistence/event-log.repository.ts
@@ -1,0 +1,25 @@
+import { TransactionHost } from '@nestjs-cls/transactional';
+import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
+import { Injectable } from '@nestjs/common';
+import { EventLogEntity } from '@prisma/client';
+
+@Injectable()
+export class EventLogPrismaRepository {
+	constructor(
+		private readonly txHost: TransactionHost<TransactionalAdapterPrisma>,
+	) {}
+
+	async create(
+		eventName: string,
+		timestamp: Date,
+		data: any,
+	): Promise<EventLogEntity> {
+		return this.txHost.tx.eventLogEntity.create({
+			data: {
+				eventName,
+				timestamp,
+				data,
+			},
+		});
+	}
+}

--- a/src/data-platform/services/data-platform.service.ts
+++ b/src/data-platform/services/data-platform.service.ts
@@ -1,9 +1,0 @@
-import { Injectable } from '@nestjs/common';
-
-@Injectable()
-export class DataPlatformService {
-	async send(payload: any): Promise<void> {
-		// 데이터분석 플랫폼에 payload 전송
-		return;
-	}
-}

--- a/src/data-platform/services/data-platform.service.ts
+++ b/src/data-platform/services/data-platform.service.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class DataPlatformService {
+	async send(payload: any): Promise<void> {
+		// 데이터분석 플랫폼에 payload 전송
+		return;
+	}
+}

--- a/src/payment/application/domain/models/user-point.ts
+++ b/src/payment/application/domain/models/user-point.ts
@@ -40,4 +40,8 @@ export class UserPoint {
 		}
 		this.balance -= amount;
 	}
+
+	refund(amount: number): void {
+		this.balance += amount;
+	}
 }

--- a/src/payment/application/domain/repositories/ipoint-history.repository.ts
+++ b/src/payment/application/domain/repositories/ipoint-history.repository.ts
@@ -1,9 +1,9 @@
-import { PrismaTransactionalClient } from '@nestjs-cls/transactional-adapter-prisma';
 import { PointHistoryEntity } from '@prisma/client';
 
 export enum PointHistoryType {
 	CHARGE = 1,
 	USE = 2,
+	REFUND = 3,
 }
 
 export interface IPointHistoryRepository {

--- a/src/payment/application/event-publishers/payment-event.publisher.ts
+++ b/src/payment/application/event-publishers/payment-event.publisher.ts
@@ -1,12 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { IEventBus } from 'src/common/interfaces/ievent-bus.interface';
 import { EVENT_BUS } from 'src/common/utils/constants';
-import {
-	PaymentFailedData,
-	PaymentFailedEvent,
-	PaymentSuccessData,
-	PaymentSuccessEvent,
-} from './payment.event';
+import { PaymentSuccessEvent } from './payment.event';
 
 @Injectable()
 export class PaymentEventPublisher {
@@ -15,13 +10,8 @@ export class PaymentEventPublisher {
 		private readonly eventBus: IEventBus,
 	) {}
 
-	async publishPaymentSuccess(data: PaymentSuccessData): Promise<void> {
-		const event = new PaymentSuccessEvent(data);
-		this.eventBus.publish(event);
-	}
-
-	async publishPaymentFailed(data: PaymentFailedData): Promise<void> {
-		const event = new PaymentFailedEvent(data);
+	async publishPaymentSuccess(reservationId: number): Promise<void> {
+		const event = new PaymentSuccessEvent({ reservationId });
 		this.eventBus.publish(event);
 	}
 }

--- a/src/payment/application/event-publishers/payment-event.publisher.ts
+++ b/src/payment/application/event-publishers/payment-event.publisher.ts
@@ -1,0 +1,27 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { IEventBus } from 'src/common/interfaces/ievent-bus.interface';
+import { EVENT_BUS } from 'src/common/utils/constants';
+import {
+	PaymentFailedData,
+	PaymentFailedEvent,
+	PaymentSuccessData,
+	PaymentSuccessEvent,
+} from './payment.event';
+
+@Injectable()
+export class PaymentEventPublisher {
+	constructor(
+		@Inject(EVENT_BUS)
+		private readonly eventBus: IEventBus,
+	) {}
+
+	async publishPaymentSuccess(data: PaymentSuccessData): Promise<void> {
+		const event = new PaymentSuccessEvent(data);
+		this.eventBus.publish(event);
+	}
+
+	async publishPaymentFailed(data: PaymentFailedData): Promise<void> {
+		const event = new PaymentFailedEvent(data);
+		this.eventBus.publish(event);
+	}
+}

--- a/src/payment/application/event-publishers/payment.event.ts
+++ b/src/payment/application/event-publishers/payment.event.ts
@@ -1,16 +1,12 @@
 import { IEvent } from 'src/common/interfaces/ievent-bus.interface';
 
 export interface PaymentSuccessData {
-	userId: number;
-	amount: number;
 	reservationId: number;
-	seatId: number;
-	concertId: number;
-	scheduleId: number;
 }
 
-export interface PaymentFailedData extends PaymentSuccessData {
-	errorMessage: string;
+export interface PaymentCancelData {
+	userId: number;
+	amount: number;
 }
 
 export class PaymentSuccessEvent implements IEvent {
@@ -24,12 +20,12 @@ export class PaymentSuccessEvent implements IEvent {
 	}
 }
 
-export class PaymentFailedEvent implements IEvent {
-	eventName = 'payment.failed';
+export class PaymentCancelEvent implements IEvent {
+	eventName = 'payment.cancel';
 	timestamp: Date;
-	data: PaymentFailedData;
+	data: PaymentCancelData;
 
-	constructor(data: PaymentFailedData) {
+	constructor(data: PaymentCancelData) {
 		this.timestamp = new Date();
 		this.data = data;
 	}

--- a/src/payment/application/event-publishers/payment.event.ts
+++ b/src/payment/application/event-publishers/payment.event.ts
@@ -1,0 +1,36 @@
+import { IEvent } from 'src/common/interfaces/ievent-bus.interface';
+
+export interface PaymentSuccessData {
+	userId: number;
+	amount: number;
+	reservationId: number;
+	seatId: number;
+	concertId: number;
+	scheduleId: number;
+}
+
+export interface PaymentFailedData extends PaymentSuccessData {
+	errorMessage: string;
+}
+
+export class PaymentSuccessEvent implements IEvent {
+	eventName = 'payment.success';
+	timestamp: Date;
+	data: PaymentSuccessData;
+
+	constructor(data: PaymentSuccessData) {
+		this.timestamp = new Date();
+		this.data = data;
+	}
+}
+
+export class PaymentFailedEvent implements IEvent {
+	eventName = 'payment.failed';
+	timestamp: Date;
+	data: PaymentFailedData;
+
+	constructor(data: PaymentFailedData) {
+		this.timestamp = new Date();
+		this.data = data;
+	}
+}

--- a/src/payment/application/services/payment.service.ts
+++ b/src/payment/application/services/payment.service.ts
@@ -10,9 +10,12 @@ import {
 import { getPaymentLockKey } from 'src/common/utils/redis-keys';
 import {
 	ChargeResponseDto,
+	PaymentProcessResponseDto,
 	PointUseResponseDto,
 } from 'src/payment/constrollers/dtos/response.dto';
+import { TokenStatus } from 'src/ticketing/application/domain/models/token';
 import { IReservationRepository } from 'src/ticketing/application/domain/repositories/ireservation.repository';
+import { PaymentTokenService } from 'src/ticketing/application/services/payment-token.service';
 import { UserPoint } from '../domain/models/user-point';
 import {
 	IPointHistoryRepository,
@@ -33,6 +36,8 @@ export class PaymentService {
 		private readonly pointHistoryRepository: IPointHistoryRepository,
 		@Inject('IReservationRepository')
 		private readonly reservationRepository: IReservationRepository,
+		@Inject('PaymentTokenService')
+		private readonly paymentTokenService: PaymentTokenService,
 		@Inject(DISTRIBUTED_LOCK_SERVICE)
 		private readonly distributedLockService: IDistributedLockService,
 		private readonly paymentEventPublisher: PaymentEventPublisher,
@@ -75,6 +80,7 @@ export class PaymentService {
 		});
 	}
 
+	// old ver.
 	async use(userId: number, amount: number): Promise<PointUseResponseDto> {
 		const startTime = Date.now();
 		// 분산락 + X-lock
@@ -92,11 +98,55 @@ export class PaymentService {
 		this.logger.log(`exec time: ${endTime - startTime}ms`);
 
 		// 이벤트 발행
-		const reservationContext =
-			await this.reservationRepository.getReservationContext(userId);
-		await this.paymentEventPublisher.publishPaymentSuccess(reservationContext);
+		// const reservationContext =
+		// 	await this.reservationRepository.getReservationContext(userId);
+		// await this.paymentEventPublisher.publishPaymentSuccess(reservationContext);
 
 		return { balance: updatedUserPoint.balance };
+	}
+
+	// new ver.
+	async processPaymentAndReservation(
+		userId: number,
+		reservationId: number,
+		paymentToken: string,
+	): Promise<PaymentProcessResponseDto> {
+		// verify
+		const isValidToken = await this.paymentTokenService.verifyToken(
+			userId,
+			paymentToken,
+			TokenStatus.WAITING,
+		);
+		if (!isValidToken) {
+			throw new Error('Invalid payment token');
+		}
+
+		// 잔액 차감
+		const reservation = await this.reservationRepository.findOne(reservationId);
+		const amount = reservation.purchasePrice;
+
+		// 분산락 + X-lock
+		const updatedUserPoint = await this.distributedLockService.withLock(
+			getPaymentLockKey(userId),
+			PAYMENT_LOCK_TTL,
+			async () => {
+				return await this._useTransaction(userId, amount);
+			},
+			10,
+			100,
+		);
+		await this.paymentTokenService.deleteToken(paymentToken); // 결제 완료시 임시 결제토큰 삭제
+
+		// 이벤트 발행
+		await this.paymentEventPublisher.publishPaymentSuccess(reservationId);
+
+		// TODO: 클라이언트 폴링으로 예약 상태 확인 (reservation.status)
+		return {
+			balance: updatedUserPoint.balance,
+			reservationId,
+			status: 'PAYMENT_COMPLETED',
+			message: '결제가 완료되었습니다. 예약 확정은 잠시 후 완료됩니다.',
+		};
 	}
 
 	async _useTransaction(userId: number, amount: number): Promise<UserPoint> {
@@ -112,6 +162,23 @@ export class PaymentService {
 			);
 			// domain logic
 			userPoint.use(amount);
+			return await this.userPointRepository.update(userPoint);
+		});
+	}
+
+	async cancelPayment(userId: number, amount: number): Promise<UserPoint> {
+		return await this.txHost.withTransaction(async () => {
+			const userPoint = await this.userPointRepository.selectForUpdate(userId);
+			if (!userPoint) {
+				throw new Error('NOT_FOUND_USER_POINT');
+			}
+			await this.pointHistoryRepository.create(
+				userId,
+				PointHistoryType.REFUND,
+				amount,
+			);
+			// domain logic
+			userPoint.refund(amount);
 			return await this.userPointRepository.update(userPoint);
 		});
 	}

--- a/src/payment/constrollers/dtos/request.dto.ts
+++ b/src/payment/constrollers/dtos/request.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsNumber } from 'class-validator';
+import { IsNumber, IsString } from 'class-validator';
 
 export class ChargeRequestDto {
 	@ApiProperty({ example: 10000, description: '충전 금액' })
@@ -14,4 +14,16 @@ export class PointUseRequestDto {
 	@Type(() => Number)
 	@IsNumber()
 	amount: number;
+}
+
+export class PaymentProcessRequestDto {
+	@ApiProperty({ example: 1, description: '예약 ID' })
+	@Type(() => Number)
+	@IsNumber()
+	reservationId: number;
+
+	@ApiProperty({ example: 'eyJhbGciOiJIUI6I...HDk', description: '결제 토큰' })
+	@Type(() => String)
+	@IsString()
+	paymentToken: string;
 }

--- a/src/payment/constrollers/dtos/response.dto.ts
+++ b/src/payment/constrollers/dtos/response.dto.ts
@@ -14,3 +14,20 @@ export class PointUseResponseDto {
 	@ApiProperty({ example: 500, description: '포인트 잔액' })
 	balance: number;
 }
+
+export class PaymentProcessResponseDto {
+	@ApiProperty({ example: 50000, description: '잔액' })
+	balance: number;
+
+	@ApiProperty({ example: 1, description: '예약 ID' })
+	reservationId: number;
+
+	@ApiProperty({ example: 'PAYMENT_COMPLETED', description: '결제 상태' })
+	status: string;
+
+	@ApiProperty({
+		example: '결제가 완료되었습니다. 예약 확정은 잠시 후 완료됩니다.',
+		description: '메시지',
+	})
+	message: string;
+}

--- a/src/payment/constrollers/payment.controller.ts
+++ b/src/payment/constrollers/payment.controller.ts
@@ -4,8 +4,16 @@ import { ApiBearerAuth, ApiOkResponse, ApiOperation } from '@nestjs/swagger';
 import { Request } from 'express';
 import { AuthGuard } from '../../auth/application/services/auth.guard';
 import { PaymentService } from '../application/services/payment.service';
-import { ChargeRequestDto, PointUseRequestDto } from './dtos/request.dto';
-import { ChargeResponseDto, PointUseResponseDto } from './dtos/response.dto';
+import {
+	ChargeRequestDto,
+	PaymentProcessRequestDto,
+	PointUseRequestDto,
+} from './dtos/request.dto';
+import {
+	ChargeResponseDto,
+	PaymentProcessResponseDto,
+	PointUseResponseDto,
+} from './dtos/response.dto';
 
 @ApiBearerAuth()
 @UseGuards(AuthGuard)
@@ -24,6 +32,7 @@ export class PaymentController {
 		return this.paymentService.charge(userId, body.amount);
 	}
 
+	// old ver.
 	@Patch('/use')
 	@ApiOperation({ summary: '포인트 결제' })
 	@ApiOkResponse({ type: PointUseResponseDto, description: '포인트 결제 성공' })
@@ -33,6 +42,21 @@ export class PaymentController {
 	): Promise<PointUseResponseDto> {
 		const userId = req.userId;
 		return this.paymentService.use(userId, body.amount);
+	}
+
+	// new ver.
+	@Patch('/process')
+	@ApiOperation({ summary: '결제 처리 및 예약 확정' })
+	async processPayment(
+		@Req() req: Request,
+		@Body() body: PaymentProcessRequestDto,
+	): Promise<PaymentProcessResponseDto> {
+		const userId = req.userId;
+		return this.paymentService.processPaymentAndReservation(
+			userId,
+			body.reservationId,
+			body.paymentToken,
+		);
 	}
 
 	@Get('/balance')

--- a/src/payment/infrastructure/event-listeners/payment-event.listener.ts
+++ b/src/payment/infrastructure/event-listeners/payment-event.listener.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
-import { DataPlatformService } from 'src/data-platform/services/data-platform.service';
+import { DataPlatformService } from 'src/data-platform/application/services/data-platform.service';
 import {
 	PaymentFailedEvent,
 	PaymentSuccessEvent,
@@ -17,8 +17,7 @@ export class PaymentEventListener {
 	async onPaymentSuccess(event: PaymentSuccessEvent): Promise<void> {
 		this.logger.log('payment.success event received');
 
-		const payload = event.data;
-		await this.dataPlatformService.send(payload);
+		await this.dataPlatformService.send(event);
 		return;
 	}
 
@@ -26,10 +25,10 @@ export class PaymentEventListener {
 	async onPaymentFailed(event: PaymentFailedEvent): Promise<void> {
 		this.logger.log('payment.failed event received');
 
-		const payload = event.data;
-		// @@@TODO 보상트랜잭션
+		// @@@TODO 결제관련 보상트랜잭션
+		// const payload = event.data;
 
-		await this.dataPlatformService.send(payload);
+		await this.dataPlatformService.send(event);
 		return;
 	}
 }

--- a/src/payment/infrastructure/event-listeners/payment-event.listener.ts
+++ b/src/payment/infrastructure/event-listeners/payment-event.listener.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
+import { OnEventSafe } from 'src/common/decorators/on-event-safe.decorator';
 import {
 	PaymentCancelEvent,
 	PaymentSuccessEvent,
@@ -16,8 +17,7 @@ export class PaymentEventListener {
 		private readonly reservationService: ReservationService,
 	) {}
 
-	// @@@TODO OnEventSafe 만들기.
-	@OnEvent('payment.success')
+	@OnEventSafe('payment.success')
 	async onPaymentSuccess(event: PaymentSuccessEvent): Promise<void> {
 		this.logger.log('payment.success event received');
 
@@ -26,7 +26,7 @@ export class PaymentEventListener {
 		return;
 	}
 
-	@OnEvent('payment.cancel')
+	@OnEventSafe('payment.cancel')
 	async onPaymentCancel(event: PaymentCancelEvent): Promise<void> {
 		this.logger.log('payment.cancel event received');
 

--- a/src/payment/infrastructure/event-listeners/payment-event.listener.ts
+++ b/src/payment/infrastructure/event-listeners/payment-event.listener.ts
@@ -1,21 +1,16 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
+import { DataPlatformService } from 'src/data-platform/services/data-platform.service';
 import {
 	PaymentFailedEvent,
 	PaymentSuccessEvent,
 } from 'src/payment/application/event-publishers/payment.event';
 
-interface DataPlatformSendService {
-	send(payload: any): Promise<void>;
-}
-
 @Injectable()
 export class PaymentEventListener {
 	private readonly logger = new Logger(PaymentEventListener.name);
 
-	constructor(
-		private readonly dataPlatformSendService: DataPlatformSendService,
-	) {}
+	constructor(private readonly dataPlatformService: DataPlatformService) {}
 
 	// @@@TODO OnEventSafe 만들기.
 	@OnEvent('payment.success')
@@ -23,7 +18,7 @@ export class PaymentEventListener {
 		this.logger.log('payment.success event received');
 
 		const payload = event.data;
-		await this.dataPlatformSendService.send(payload);
+		await this.dataPlatformService.send(payload);
 		return;
 	}
 
@@ -34,7 +29,7 @@ export class PaymentEventListener {
 		const payload = event.data;
 		// @@@TODO 보상트랜잭션
 
-		await this.dataPlatformSendService.send(payload);
+		await this.dataPlatformService.send(payload);
 		return;
 	}
 }

--- a/src/payment/infrastructure/event-listeners/payment-event.listener.ts
+++ b/src/payment/infrastructure/event-listeners/payment-event.listener.ts
@@ -1,0 +1,40 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import {
+	PaymentFailedEvent,
+	PaymentSuccessEvent,
+} from 'src/payment/application/event-publishers/payment.event';
+
+interface DataPlatformSendService {
+	send(payload: any): Promise<void>;
+}
+
+@Injectable()
+export class PaymentEventListener {
+	private readonly logger = new Logger(PaymentEventListener.name);
+
+	constructor(
+		private readonly dataPlatformSendService: DataPlatformSendService,
+	) {}
+
+	// @@@TODO OnEventSafe 만들기.
+	@OnEvent('payment.success')
+	async onPaymentSuccess(event: PaymentSuccessEvent): Promise<void> {
+		this.logger.log('payment.success event received');
+
+		const payload = event.data;
+		await this.dataPlatformSendService.send(payload);
+		return;
+	}
+
+	@OnEvent('payment.failed')
+	async onPaymentFailed(event: PaymentFailedEvent): Promise<void> {
+		this.logger.log('payment.failed event received');
+
+		const payload = event.data;
+		// @@@TODO 보상트랜잭션
+
+		await this.dataPlatformSendService.send(payload);
+		return;
+	}
+}

--- a/src/payment/payment.module.ts
+++ b/src/payment/payment.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { PaymentEventPublisher } from './application/event-publishers/payment-event.publisher';
 import { PaymentService } from './application/services/payment.service';
 import { PaymentController } from './constrollers/payment.controller';
 import { PointHistoryPrismaRepository } from './infrastructure/persistence/point-history.repository';
@@ -13,6 +14,7 @@ import { UserPointPrismaRepository } from './infrastructure/persistence/user-poi
 			provide: 'IPointHistoryRepository',
 			useClass: PointHistoryPrismaRepository,
 		},
+		PaymentEventPublisher,
 	],
 	exports: [PaymentService],
 })

--- a/src/payment/payment.module.ts
+++ b/src/payment/payment.module.ts
@@ -4,6 +4,7 @@ import { TicketingModule } from '../ticketing/ticketing.module';
 import { PaymentEventPublisher } from './application/event-publishers/payment-event.publisher';
 import { PaymentService } from './application/services/payment.service';
 import { PaymentController } from './constrollers/payment.controller';
+import { PaymentEventListener } from './infrastructure/event-listeners/payment-event.listener';
 import { PointHistoryPrismaRepository } from './infrastructure/persistence/point-history.repository';
 import { UserPointPrismaRepository } from './infrastructure/persistence/user-point.repository';
 
@@ -18,6 +19,7 @@ import { UserPointPrismaRepository } from './infrastructure/persistence/user-poi
 			useClass: PointHistoryPrismaRepository,
 		},
 		PaymentEventPublisher,
+		PaymentEventListener,
 	],
 	exports: [PaymentService],
 })

--- a/src/payment/payment.module.ts
+++ b/src/payment/payment.module.ts
@@ -1,4 +1,6 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
+import { DataPlatformModule } from '../data-platform/data-platform.module';
+import { TicketingModule } from '../ticketing/ticketing.module';
 import { PaymentEventPublisher } from './application/event-publishers/payment-event.publisher';
 import { PaymentService } from './application/services/payment.service';
 import { PaymentController } from './constrollers/payment.controller';
@@ -6,6 +8,7 @@ import { PointHistoryPrismaRepository } from './infrastructure/persistence/point
 import { UserPointPrismaRepository } from './infrastructure/persistence/user-point.repository';
 
 @Module({
+	imports: [forwardRef(() => TicketingModule), DataPlatformModule],
 	controllers: [PaymentController],
 	providers: [
 		PaymentService,

--- a/src/queue/main.worker.ts
+++ b/src/queue/main.worker.ts
@@ -7,11 +7,7 @@ import { ReservationExpireConsumer } from './services/reservation-expire-consume
 export const initializeAndStartWorkers = async (
 	app: INestApplicationContext,
 ): Promise<void> => {
-	const queueConsumer = app.get(QueueConsumer);
 	const reservationExpireConsumer = app.get(ReservationExpireConsumer);
-
-	await queueConsumer.loadQueuesFromRedis();
-	await queueConsumer.initializeAndStartWorkers();
 
 	await reservationExpireConsumer.initializeAndStartWorkers();
 };

--- a/src/ticketing/application/domain/repositories/ireservation.repository.ts
+++ b/src/ticketing/application/domain/repositories/ireservation.repository.ts
@@ -1,4 +1,5 @@
 import { PrismaTransactionalClient } from '@nestjs-cls/transactional-adapter-prisma';
+import { PaymentSuccessData } from 'src/payment/application/event-publishers/payment.event';
 import {
 	Reservation,
 	ReservationProps,
@@ -17,4 +18,5 @@ export interface IReservationRepository {
 		reservation: Reservation,
 		expectedStatus: ReservationStatus,
 	): Promise<Reservation>;
+	getReservationContext(reservationId: number): Promise<PaymentSuccessData>;
 }

--- a/src/ticketing/application/event-publishers/reservation-event.publisher.ts
+++ b/src/ticketing/application/event-publishers/reservation-event.publisher.ts
@@ -1,12 +1,12 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { IEventBus } from 'src/common/interfaces/ievent-bus.interface';
 import { EVENT_BUS } from 'src/common/utils/constants';
-import { Reservation } from '../domain/models/reservation';
 import {
-	ReservationFailedData,
-	ReservationFailedEvent,
-	ReservationSuccessEvent,
-} from './reservation-event';
+	PaymentCancelData,
+	PaymentCancelEvent,
+} from 'src/payment/application/event-publishers/payment.event';
+import { Reservation } from '../domain/models/reservation';
+import { ReservationSuccessEvent } from './reservation-event';
 
 @Injectable()
 export class ReservationEventPublisher {
@@ -20,8 +20,8 @@ export class ReservationEventPublisher {
 		this.eventBus.publish(event);
 	}
 
-	publishReservationFailed(data: ReservationFailedData): void {
-		const event = new ReservationFailedEvent(data);
+	publishPaymentCancel(data: PaymentCancelData): void {
+		const event = new PaymentCancelEvent(data);
 		this.eventBus.publish(event);
 	}
 }

--- a/src/ticketing/application/event-publishers/reservation-event.publisher.ts
+++ b/src/ticketing/application/event-publishers/reservation-event.publisher.ts
@@ -1,0 +1,27 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { IEventBus } from 'src/common/interfaces/ievent-bus.interface';
+import { EVENT_BUS } from 'src/common/utils/constants';
+import { Reservation } from '../domain/models/reservation';
+import {
+	ReservationFailedData,
+	ReservationFailedEvent,
+	ReservationSuccessEvent,
+} from './reservation-event';
+
+@Injectable()
+export class ReservationEventPublisher {
+	constructor(
+		@Inject(EVENT_BUS)
+		private readonly eventBus: IEventBus,
+	) {}
+
+	publishReservationSuccess(data: Reservation): void {
+		const event = new ReservationSuccessEvent(data);
+		this.eventBus.publish(event);
+	}
+
+	publishReservationFailed(data: ReservationFailedData): void {
+		const event = new ReservationFailedEvent(data);
+		this.eventBus.publish(event);
+	}
+}

--- a/src/ticketing/application/event-publishers/reservation-event.ts
+++ b/src/ticketing/application/event-publishers/reservation-event.ts
@@ -1,0 +1,28 @@
+import { IEvent } from 'src/common/interfaces/ievent-bus.interface';
+import { Reservation } from '../domain/models/reservation';
+
+export interface ReservationFailedData extends Reservation {
+	errorMessage: string;
+}
+
+export class ReservationSuccessEvent implements IEvent {
+	eventName = 'reservation.success';
+	timestamp: Date;
+	data: Reservation;
+
+	constructor(data: Reservation) {
+		this.timestamp = new Date();
+		this.data = data;
+	}
+}
+
+export class ReservationFailedEvent implements IEvent {
+	eventName = 'reservation.failed';
+	timestamp: Date;
+	data: ReservationFailedData;
+
+	constructor(data: ReservationFailedData) {
+		this.timestamp = new Date();
+		this.data = data;
+	}
+}

--- a/src/ticketing/application/event-publishers/reservation-event.ts
+++ b/src/ticketing/application/event-publishers/reservation-event.ts
@@ -1,27 +1,12 @@
 import { IEvent } from 'src/common/interfaces/ievent-bus.interface';
 import { Reservation } from '../domain/models/reservation';
 
-export interface ReservationFailedData extends Reservation {
-	errorMessage: string;
-}
-
 export class ReservationSuccessEvent implements IEvent {
 	eventName = 'reservation.success';
 	timestamp: Date;
 	data: Reservation;
 
 	constructor(data: Reservation) {
-		this.timestamp = new Date();
-		this.data = data;
-	}
-}
-
-export class ReservationFailedEvent implements IEvent {
-	eventName = 'reservation.failed';
-	timestamp: Date;
-	data: ReservationFailedData;
-
-	constructor(data: ReservationFailedData) {
 		this.timestamp = new Date();
 		this.data = data;
 	}

--- a/src/ticketing/application/services/queue-ranking.service.ts
+++ b/src/ticketing/application/services/queue-ranking.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { RedisService } from 'src/common/services/redis/redis.service';
 import {
 	activeQueueKey,
@@ -7,10 +7,14 @@ import {
 } from 'src/common/utils/redis-keys';
 
 @Injectable()
-export class QueueRankingService {
+export class QueueRankingService implements OnModuleInit {
 	private readonly logger = new Logger(QueueRankingService.name);
 
 	constructor(private readonly redisService: RedisService) {}
+
+	async onModuleInit(): Promise<void> {
+		await this.initialize();
+	}
 
 	async initialize(): Promise<void> {
 		await this.redisService.delete(waitingQueueKey());
@@ -42,8 +46,10 @@ export class QueueRankingService {
 		let waitingCount = Number(await this.redisService.zcard(waitingQueueKey()));
 		while (activeCount < maxCount && waitingCount > 0) {
 			// waiting queue의 1순위를 active queue로 전환
-			const token = await this.redisService.zrange(waitingQueueKey(), 0, 0)[0];
-			this.logger.log('1st rank token: ', token.slice(0, 10));
+			const token = (
+				await this.redisService.zrange(waitingQueueKey(), 0, 0)
+			)[0];
+			console.log('1st rank token: ', token.slice(0, 10));
 			await this.redisService.zrem(waitingQueueKey(), token);
 			await this.redisService.zadd(activeQueueKey(), Date.now(), token);
 			// update count
@@ -86,5 +92,30 @@ export class QueueRankingService {
 		}
 		// 둘 다 없으면 권한 X
 		return result;
+	}
+
+	async deleteFromWaitingQueue(token: string): Promise<number> {
+		return this.redisService.zrem(waitingQueueKey(), token);
+	}
+
+	async deleteFromActiveQueue(token: string): Promise<number> {
+		return this.redisService.zrem(activeQueueKey(), token);
+	}
+
+	async _showQueues(): Promise<void> {
+		const waitingQueue = await this.redisService.zrange(
+			waitingQueueKey(),
+			0,
+			-1,
+			true,
+		);
+		const activeQueue = await this.redisService.zrange(
+			activeQueueKey(),
+			0,
+			-1,
+			true,
+		);
+		console.log('waitingQueue', waitingQueue);
+		console.log('activeQueue', activeQueue);
 	}
 }

--- a/src/ticketing/application/services/queue-ranking.service.ts
+++ b/src/ticketing/application/services/queue-ranking.service.ts
@@ -1,26 +1,10 @@
-import {
-	BadRequestException,
-	Inject,
-	Injectable,
-	Logger,
-} from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { RedisService } from 'src/common/services/redis/redis.service';
 import {
 	activeQueueKey,
-	getBookedCountKey,
-	getDurationKey,
-	getFastSelloutRankingKey,
-	getSellingStartTimeKey,
-	getTotalSeatsCountKey,
 	maxActiveUsersCountKey,
-	maxActiveUsersKey,
 	waitingQueueKey,
 } from 'src/common/utils/redis-keys';
-import {
-	FastSelloutRankingItem,
-	FastSelloutRankingResponseDto,
-} from 'src/ticketing/controllers/dtos/response.dto';
-import { IConcertRepository } from '../domain/repositories/iconcert.repository';
 
 @Injectable()
 export class QueueRankingService {
@@ -31,7 +15,7 @@ export class QueueRankingService {
 	async initialize(): Promise<void> {
 		await this.redisService.delete(waitingQueueKey());
 		await this.redisService.delete(activeQueueKey());
-		await this.redisService.set(maxActiveUsersKey(), 10); // 동시접속 10명
+		await this.redisService.set(maxActiveUsersCountKey(), 10); // 동시접속 10명
 	}
 
 	/**

--- a/src/ticketing/application/services/queue-token.service.int.spec.ts
+++ b/src/ticketing/application/services/queue-token.service.int.spec.ts
@@ -82,15 +82,6 @@ describe('QueueTokenService Integration Test', () => {
 	describe('verifyToken', () => {
 		it('대기열 토큰을 검증한다', async () => {
 			// given
-			const concertId = 1;
-			await TestWorkerSimulator.addJobAndStartProcess(
-				queueProducer,
-				queueConsumer,
-				queueTokenService,
-				concertId,
-				queueToken,
-			);
-
 			// when
 			const result = await queueTokenService.verifyToken(
 				userId,

--- a/src/ticketing/application/services/reservation.service.concurrency.e2e.spec.ts
+++ b/src/ticketing/application/services/reservation.service.concurrency.e2e.spec.ts
@@ -126,17 +126,6 @@ describe('ReservationService E2E Test', () => {
 			queueTokens.push(res.body.token);
 		}
 
-		// 대기열 통과
-		for (let i = 0; i < numUsers; i++) {
-			await TestWorkerSimulator.addJobAndStartProcess(
-				queueProducer,
-				queueConsumer,
-				queueTokenService,
-				concert.id,
-				queueTokens[i],
-			);
-		}
-
 		// 동시 예약 요청
 		const promises = [];
 		for (let i = 0; i < numUsers; i++) {
@@ -197,17 +186,6 @@ describe('ReservationService E2E Test', () => {
 				.expect(201);
 			const queueToken = res.body.token;
 			queueTokens.push(queueToken);
-		}
-
-		// 대기열 통과
-		for (let i = 0; i < numUsers; i++) {
-			await TestWorkerSimulator.addJobAndStartProcess(
-				queueProducer,
-				queueConsumer,
-				queueTokenService,
-				concert.id,
-				queueTokens[i],
-			);
 		}
 
 		// 유저 1의 예약 요청

--- a/src/ticketing/application/services/reservation.service.int.app.spec.ts
+++ b/src/ticketing/application/services/reservation.service.int.app.spec.ts
@@ -5,6 +5,7 @@ import { IUserPointRepository } from 'src/payment/application/domain/repositorie
 import { PaymentService } from 'src/payment/application/services/payment.service';
 import { ReservationStatus } from '../domain/models/reservation';
 import { SeatStatus } from '../domain/models/seat';
+import { IReservationRepository } from '../domain/repositories/ireservation.repository';
 import { ISeatRepository } from '../domain/repositories/iseat.repository';
 import { QueueRankingService } from './queue-ranking.service';
 import { QueueTokenService } from './queue-token.service';
@@ -15,6 +16,7 @@ describe('ReservationService', () => {
 	let reservationService: ReservationService;
 	let seatRepository: ISeatRepository;
 	let userPointRepository: IUserPointRepository;
+	let reservationRepository: IReservationRepository;
 	let queueTokenService: QueueTokenService;
 	let paymentService: PaymentService;
 	let queueRankingService: QueueRankingService;
@@ -30,6 +32,9 @@ describe('ReservationService', () => {
 		reservationService = app.get<ReservationService>(ReservationService);
 		seatRepository = app.get<ISeatRepository>('ISeatRepository');
 		userPointRepository = app.get<IUserPointRepository>('IUserPointRepository');
+		reservationRepository = app.get<IReservationRepository>(
+			'IReservationRepository',
+		);
 		queueTokenService = app.get<QueueTokenService>('QueueTokenService');
 		paymentService = app.get<PaymentService>(PaymentService);
 		queueRankingService = app.get<QueueRankingService>(QueueRankingService);
@@ -40,7 +45,7 @@ describe('ReservationService', () => {
 	const userId = 1;
 	const concertId = 1;
 	const scheduleId = 1;
-	const seatId = 10;
+	const seatId = 13;
 
 	// 유저가 토큰을 발급받고 → 좌석 예약 요청 → 결제 완료까지의 흐름 테스트
 	it('예약 흐름 테스트', async () => {
@@ -57,25 +62,22 @@ describe('ReservationService', () => {
 		const { reservationId, paymentToken } =
 			await reservationService.temporaryReserve(userId, seatId, token);
 
-		// 결제 완료
-		const { reservation } = await reservationService.confirmReservation(
+		// 결제 완료 및 예약확정(이벤트)
+		await paymentService.processPaymentAndReservation(
 			userId,
 			reservationId,
 			paymentToken,
 		);
-		console.log('reservation', reservation);
 
+		await new Promise((resolve) => setTimeout(resolve, 1000));
+
+		// 예약확정 확인: 1. reservation 2. seat
+		const reservation = await reservationRepository.findOne(reservationId);
 		expect(reservation).toBeDefined();
 		expect(reservation.status).toBe(ReservationStatus.CONFIRMED);
 		expect(reservation.paidAt).toBeInstanceOf(Date);
 
 		const seatAfter = await seatRepository.findOne(reservation.seatId);
 		expect(seatAfter.status).toBe(SeatStatus.SOLD);
-
-		// 이벤트 리스닝 확인
-		// 1. 최종예약 -> 결제
-		const userPointAfter = await userPointRepository.findOne(userId);
-		console.log('userPointAfter', userPointAfter);
-		// expect(userPointAfter.balance).toBe(0);
 	});
 });

--- a/src/ticketing/application/services/reservation.service.int.app.spec.ts
+++ b/src/ticketing/application/services/reservation.service.int.app.spec.ts
@@ -1,0 +1,81 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppModule } from 'src/app.module';
+import { IUserPointRepository } from 'src/payment/application/domain/repositories/iuser-point.repository';
+import { PaymentService } from 'src/payment/application/services/payment.service';
+import { ReservationStatus } from '../domain/models/reservation';
+import { SeatStatus } from '../domain/models/seat';
+import { ISeatRepository } from '../domain/repositories/iseat.repository';
+import { QueueRankingService } from './queue-ranking.service';
+import { QueueTokenService } from './queue-token.service';
+import { ReservationService } from './reservation.service';
+
+describe('ReservationService', () => {
+	let app: INestApplication;
+	let reservationService: ReservationService;
+	let seatRepository: ISeatRepository;
+	let userPointRepository: IUserPointRepository;
+	let queueTokenService: QueueTokenService;
+	let paymentService: PaymentService;
+	let queueRankingService: QueueRankingService;
+
+	beforeAll(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			imports: [AppModule],
+		}).compile();
+
+		app = module.createNestApplication();
+		await app.init();
+
+		reservationService = app.get<ReservationService>(ReservationService);
+		seatRepository = app.get<ISeatRepository>('ISeatRepository');
+		userPointRepository = app.get<IUserPointRepository>('IUserPointRepository');
+		queueTokenService = app.get<QueueTokenService>('QueueTokenService');
+		paymentService = app.get<PaymentService>(PaymentService);
+		queueRankingService = app.get<QueueRankingService>(QueueRankingService);
+
+		await queueRankingService.initialize();
+	});
+
+	const userId = 1;
+	const concertId = 1;
+	const scheduleId = 1;
+	const seatId = 10;
+
+	// 유저가 토큰을 발급받고 → 좌석 예약 요청 → 결제 완료까지의 흐름 테스트
+	it('예약 흐름 테스트', async () => {
+		// given
+		const { token } = await queueTokenService.createToken({
+			userId,
+			concertId,
+		});
+
+		// 충전
+		await paymentService.charge(userId, 150000);
+
+		// 예약 요청
+		const { reservationId, paymentToken } =
+			await reservationService.temporaryReserve(userId, seatId, token);
+
+		// 결제 완료
+		const { reservation } = await reservationService.confirmReservation(
+			userId,
+			reservationId,
+			paymentToken,
+		);
+		console.log('reservation', reservation);
+
+		expect(reservation).toBeDefined();
+		expect(reservation.status).toBe(ReservationStatus.CONFIRMED);
+		expect(reservation.paidAt).toBeInstanceOf(Date);
+
+		const seatAfter = await seatRepository.findOne(reservation.seatId);
+		expect(seatAfter.status).toBe(SeatStatus.SOLD);
+
+		// 이벤트 리스닝 확인
+		// 1. 최종예약 -> 결제
+		const userPointAfter = await userPointRepository.findOne(userId);
+		console.log('userPointAfter', userPointAfter);
+		// expect(userPointAfter.balance).toBe(0);
+	});
+});

--- a/src/ticketing/application/services/reservation.service.ts
+++ b/src/ticketing/application/services/reservation.service.ts
@@ -100,7 +100,7 @@ export class ReservationService {
 						1, // 재시도 X. 한 요청만 락을 획득하고 나머지는 실패하는것이 정상
 					);
 
-				// Write back to cache
+				// Write back to cache (좌석정보)
 				const cacheKey = getSeatsCacheKey(seatId);
 				const obj = {
 					[seatId]: {
@@ -117,6 +117,9 @@ export class ReservationService {
 					seatId,
 				});
 				paymentToken = token;
+
+				// 대기열 토큰 삭제
+				await this.queueTokenService.deleteToken(queueToken);
 			} catch (error) {
 				this.logger.error(error);
 				throw new Error('FAILED_TO_ACQUIRE_LOCK'); // 이미 예약된 좌석입니다

--- a/src/ticketing/application/services/reservation.service.ts
+++ b/src/ticketing/application/services/reservation.service.ts
@@ -72,7 +72,6 @@ export class ReservationService {
 			}
 
 			// domain logic
-			console.log('seatId', seatId);
 			const seat = await this.seatRepository.findOne(seatId);
 			seat.setReserved();
 			const reservation = new Reservation({

--- a/src/ticketing/controllers/dtos/request.dto.ts
+++ b/src/ticketing/controllers/dtos/request.dto.ts
@@ -28,13 +28,6 @@ export class PaymentRequestDto {
 	@Type(() => Number)
 	@IsNumber()
 	reservationId: number;
-
-	@ApiProperty({
-		example: 'eyJhbGciOiJIUI6I...HDk',
-		description: '결제 대기 토큰',
-	})
-	@IsString()
-	paymentToken: string;
 }
 
 export class ConcertScheduleRequestDto {

--- a/src/ticketing/controllers/reservation.controller.ts
+++ b/src/ticketing/controllers/reservation.controller.ts
@@ -75,16 +75,8 @@ export class ReservationController {
 	@Post('/confirm')
 	@ApiOperation({ summary: '결제 요청' })
 	@ApiOkResponse({ type: PaymentResponseDto, description: '결제 요청 성공' })
-	async payment(
-		@Req() req: Request,
-		@Body() body: PaymentRequestDto,
-	): Promise<PaymentResponseDto> {
-		const userId = req.userId;
-		return this.reservationService.confirmReservation(
-			userId,
-			body.reservationId,
-			body.paymentToken,
-		);
+	async payment(@Body() body: PaymentRequestDto): Promise<PaymentResponseDto> {
+		return this.reservationService.confirmReservation(body.reservationId);
 	}
 
 	// 예약 현황 조회

--- a/src/ticketing/infrastructure/event-listeners/reservation-event.listener.ts
+++ b/src/ticketing/infrastructure/event-listeners/reservation-event.listener.ts
@@ -1,0 +1,39 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { DataPlatformService } from 'src/data-platform/application/services/data-platform.service';
+import { PaymentService } from 'src/payment/application/services/payment.service';
+import {
+	ReservationFailedEvent,
+	ReservationSuccessEvent,
+} from 'src/ticketing/application/event-publishers/reservation-event';
+
+@Injectable()
+export class ReservationEventListener {
+	private readonly logger = new Logger(ReservationEventListener.name);
+
+	constructor(
+		private readonly dataPlatformService: DataPlatformService,
+		private readonly paymentService: PaymentService,
+	) {}
+
+	// @@@TODO OnEventSafe 만들기.
+	@OnEvent('reservation.success')
+	async onReservationSuccess(event: ReservationSuccessEvent): Promise<void> {
+		this.logger.log('reservation.success event received');
+
+		await this.paymentService.use(event.data.userId, event.data.purchasePrice);
+		await this.dataPlatformService.send(event);
+		return;
+	}
+
+	@OnEvent('reservation.failed')
+	async onReservationFailed(event: ReservationFailedEvent): Promise<void> {
+		this.logger.log('reservation.failed event received');
+
+		// @@@TODO 예약관련 보상트랜잭션
+		// const payload = event.data;
+
+		await this.dataPlatformService.send(event);
+		return;
+	}
+}

--- a/src/ticketing/infrastructure/event-listeners/reservation-event.listener.ts
+++ b/src/ticketing/infrastructure/event-listeners/reservation-event.listener.ts
@@ -1,37 +1,18 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
 import { DataPlatformService } from 'src/data-platform/application/services/data-platform.service';
-import { PaymentService } from 'src/payment/application/services/payment.service';
-import {
-	ReservationFailedEvent,
-	ReservationSuccessEvent,
-} from 'src/ticketing/application/event-publishers/reservation-event';
+import { ReservationSuccessEvent } from 'src/ticketing/application/event-publishers/reservation-event';
 
 @Injectable()
 export class ReservationEventListener {
 	private readonly logger = new Logger(ReservationEventListener.name);
 
-	constructor(
-		private readonly dataPlatformService: DataPlatformService,
-		private readonly paymentService: PaymentService,
-	) {}
+	constructor(private readonly dataPlatformService: DataPlatformService) {}
 
 	// @@@TODO OnEventSafe 만들기.
 	@OnEvent('reservation.success')
 	async onReservationSuccess(event: ReservationSuccessEvent): Promise<void> {
 		this.logger.log('reservation.success event received');
-
-		await this.paymentService.use(event.data.userId, event.data.purchasePrice);
-		await this.dataPlatformService.send(event);
-		return;
-	}
-
-	@OnEvent('reservation.failed')
-	async onReservationFailed(event: ReservationFailedEvent): Promise<void> {
-		this.logger.log('reservation.failed event received');
-
-		// @@@TODO 예약관련 보상트랜잭션
-		// const payload = event.data;
 
 		await this.dataPlatformService.send(event);
 		return;

--- a/src/ticketing/infrastructure/event-listeners/reservation-event.listener.ts
+++ b/src/ticketing/infrastructure/event-listeners/reservation-event.listener.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
+import { OnEventSafe } from 'src/common/decorators/on-event-safe.decorator';
 import { DataPlatformService } from 'src/data-platform/application/services/data-platform.service';
 import { ReservationSuccessEvent } from 'src/ticketing/application/event-publishers/reservation-event';
 
@@ -9,8 +10,7 @@ export class ReservationEventListener {
 
 	constructor(private readonly dataPlatformService: DataPlatformService) {}
 
-	// @@@TODO OnEventSafe 만들기.
-	@OnEvent('reservation.success')
+	@OnEventSafe('reservation.success')
 	async onReservationSuccess(event: ReservationSuccessEvent): Promise<void> {
 		this.logger.log('reservation.success event received');
 

--- a/src/ticketing/ticketing.module.ts
+++ b/src/ticketing/ticketing.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { PaymentModule } from '../payment/payment.module';
 import { EventSearchService } from './application/services/event-search.service';
 import { PaymentTokenService } from './application/services/payment-token.service';
@@ -16,7 +16,7 @@ import { ReservationPrismaRepository } from './infrastructure/persistence/reserv
 import { SeatPrismaRepository } from './infrastructure/persistence/seat.prisma.repository';
 
 @Module({
-	imports: [PaymentModule],
+	imports: [forwardRef(() => PaymentModule)],
 	providers: [
 		EventSearchService,
 		ReservationService,

--- a/src/ticketing/ticketing.module.ts
+++ b/src/ticketing/ticketing.module.ts
@@ -45,6 +45,8 @@ import { SeatPrismaRepository } from './infrastructure/persistence/seat.prisma.r
 	],
 	exports: [
 		SeatLockService,
+		ReservationService,
+		{ provide: 'PaymentTokenService', useClass: PaymentTokenService },
 		{
 			provide: 'IReservationRepository',
 			useClass: ReservationPrismaRepository,

--- a/src/ticketing/ticketing.module.ts
+++ b/src/ticketing/ticketing.module.ts
@@ -1,5 +1,7 @@
 import { Module, forwardRef } from '@nestjs/common';
+import { DataPlatformModule } from 'src/data-platform/data-platform.module';
 import { PaymentModule } from '../payment/payment.module';
+import { ReservationEventPublisher } from './application/event-publishers/reservation-event.publisher';
 import { EventSearchService } from './application/services/event-search.service';
 import { PaymentTokenService } from './application/services/payment-token.service';
 import { QueueRankingService } from './application/services/queue-ranking.service';
@@ -10,13 +12,14 @@ import { SelloutRankingService } from './application/services/sellout-ranking.se
 import { EventSearchController } from './controllers/event-search.controller';
 import { RankingController } from './controllers/ranking.controller';
 import { ReservationController } from './controllers/reservation.controller';
+import { ReservationEventListener } from './infrastructure/event-listeners/reservation-event.listener';
 import { QueueProducer } from './infrastructure/external/queue-producer.service';
 import { ConcertPrismaRepository } from './infrastructure/persistence/concert.prisma.repository';
 import { ReservationPrismaRepository } from './infrastructure/persistence/reservation.prisma.repository';
 import { SeatPrismaRepository } from './infrastructure/persistence/seat.prisma.repository';
 
 @Module({
-	imports: [forwardRef(() => PaymentModule)],
+	imports: [forwardRef(() => PaymentModule), DataPlatformModule],
 	providers: [
 		EventSearchService,
 		ReservationService,
@@ -32,6 +35,8 @@ import { SeatPrismaRepository } from './infrastructure/persistence/seat.prisma.r
 			useClass: ReservationPrismaRepository,
 		},
 		QueueProducer,
+		ReservationEventPublisher,
+		ReservationEventListener,
 	],
 	controllers: [
 		EventSearchController,

--- a/test/utils/worker-simulator.ts
+++ b/test/utils/worker-simulator.ts
@@ -7,22 +7,6 @@ import { QueueProducer } from 'src/ticketing/infrastructure/external/queue-produ
 export class TestWorkerSimulator {
 	private constructor() {}
 
-	static async addJobAndStartProcess(
-		queueProducer: QueueProducer,
-		queueConsumer: QueueConsumer,
-		queueTokenService: QueueTokenService,
-		concertId: number,
-		queueToken: string,
-	): Promise<void> {
-		// 대기열 진입
-		const job = await queueProducer.addJob(getQueueName(concertId), {
-			token: queueToken,
-		});
-		// 워커 함수 직접 호출 (대기열 통과)
-		await queueConsumer.process(job);
-		await queueTokenService.checkAndUpdateTokenStatus(queueToken);
-	}
-
 	static addDelayJobAndExpire = async (
 		queueProducer: QueueProducer,
 		expirationConsumer: ReservationExpireConsumer,


### PR DESCRIPTION
### **커밋 설명**
- Event Bus 인터페이스 및 결제 이벤트 추가 : 09c0798
- 이벤트 순서 변경, 예약 실패시 보상트랜잭션 이벤트 추가 : 474c0d3
- MSA 아키텍처 설계 : ed76fc8

### **구현 도식화**
<img width="1592" height="754" alt="image" src="https://github.com/user-attachments/assets/7b1998b8-983d-482a-ade0-e439b1321be5" />

---
이벤트 기반 비동기 예약 플로우
<img width="2184" height="676" alt="image" src="https://github.com/user-attachments/assets/7b41c572-d382-41e2-ac39-1d4181016e85" />

---
### **리뷰 받고 싶은 내용(질문)**
### 1. 도메인별 이벤트 publisher, listener의 적절한 경계
- 최종예약 실패시 `reservation.fail` 이벤트 -> `payment.cancel` 이벤트가 아니라 
catch 블록에서 즉시 `payment.cancel` 이벤트를 부르고 있는데, 적절하지 않은 구조일까요?
- `reservation.fail` 이벤트를 발행하고 리스너에서 `payment.cancel` 보상 트랜잭션을 호출해도 되지만 불필요한 단계가 추가되는 것 같아 `reservation.fail` 이벤트를 생략했습니다.
- 구현상 중요치 않은 부분일 수는 있으나, reservation-event.publisher.ts 안에서 `payment.cancel`이라는 이름의 이벤트를 발행하는 게 어색하게 느껴져서 여쭤봅니다.

폴더구조
```python
src/
├── payment/
│   └── application/
│       └── event-publishers/
│           └── payment-event.publisher.ts  # 결제 관련 이벤트 발행
│   └── infrastructure/
│       └── event-listeners/
│           └── payment-event.listener.ts    # 결제 관련 이벤트 처리
├── ticketing/
│   └── application/
│       └── event-publishers/
│           └── reservation-event.publisher.ts # 예약 관련 이벤트 발행
│   └── infrastructure/
│       └── event-listeners/
│           └── reservation-event.listener.ts # 예약 관련 이벤트 처리
```

```typescript
// reservation.service.ts
async confirmReservation(reservationId: number): Promise<PaymentResponseDto> {
	try {
		// 좌석 최종 배정
		const { reservation, seat } = await this.txHost.withTransaction(
			async () => {
				return await this._confirmWithOptimisticLock(reservationId);
			},
		);

		// 좌석예약 성공시 이벤트 발행 -> 결제 모듈 호출
		if (reservation.status === ReservationStatus.CONFIRMED) {
			this.reservationEventPublisher.publishReservationSuccess(reservation);
		}
		return {
			reservation: {
				id: reservation.id,
				seatId: reservation.seatId,
				purchasePrice: reservation.purchasePrice,
				status: reservation.status,
				paidAt: reservation.paidAt,
			},
		};
	} catch (error) {
		this.logger.error(error);
		// 보상 트랜잭션 이벤트 호출
		const reservation =
			await this.reservationRepository.findOne(reservationId);
		this.reservationEventPublisher.publishPaymentCancel({
			userId: reservation.userId,
			amount: reservation.purchasePrice,
		});
	}
}

// reservation-event.publisher.ts
@Injectable()
export class ReservationEventPublisher {
	constructor(
		@Inject(EVENT_BUS)
		private readonly eventBus: IEventBus,
	) {}

	publishReservationSuccess(data: Reservation): void {
		const event = new ReservationSuccessEvent(data);
		this.eventBus.publish(event);
	}

	publishPaymentCancel(data: PaymentCancelData): void {
		const event = new PaymentCancelEvent(data);
		this.eventBus.publish(event);
	}
}

```

---
### 2. 클라이언트에서 비동기 이벤트 성공여부 파악하는 방법
- 현재 결제완료 -> 최종예약 구조에서, 결제완료 직후 클라이언트에 먼저 성공 응답을 하고 있습니다. 
- 클라이언트는 polling으로 최종예약까지 성공했는지 파악해야하는데, 대략 1초 간격으로 확인해서 reservation.status가 `CONFIRM`으로 변경되었는지 알면 되는걸까요? 이 경우 적당한 타임아웃을 설정하는 것도 애매한 것 같습니다..(10초가 지나도 `PENDING`이면 예약실패, 결제 환불처리했으나 외부 API에서는 뒤늦게 결제가 완료된 경우가 발생할 가능성)
- polling 구조에서 클라이언트 응답과 외부 결제 API간 멱등성을 안정적으로 처리하는 방법이 있을지 여쭤봅니다.
```typescript
return {
	balance: updatedUserPoint.balance,
	reservationId,
	status: 'PAYMENT_COMPLETED',
	message: '결제가 완료되었습니다. 예약 확정은 잠시 후 완료됩니다.',
};
```

---

### **과제 셀프 피드백**
- 단일 트랜잭션을 이벤트 기반 구조로 변경함으로써, 핵심로직과 부가로직을 분리해서 생각하는 연습을 할 수 있었음.
- 트랜잭션 커밋 후 이벤트를 발행함으로써- 현재 이벤트에서 실패는 roll back함과 동시에 이전 이벤트는 보상 트랜잭션 이벤트를 발행함으로써 데이터 일관성을 지키는 방법도 알게됨.
- 비동기 이벤트 구조에서 어느시점에 전체 흐름이 끝까지 성공했다고 판단할 수 있는지에 대한 애매함이 있음.
